### PR TITLE
Faster Usernameify

### DIFF
--- a/tools/inflector/inflector.go
+++ b/tools/inflector/inflector.go
@@ -93,26 +93,19 @@ func Snakecase(str string) string {
 // Usernamify("John Doe,   hello") // "john.doe.hello"
 // ```
 func Usernamify(str string) string {
-	// split at any non word character
-	words := usernamifySplitRegex.Split(strings.ToLower(str), -1)
-
-	// concatenate any non empty word with a dot
-	var result strings.Builder
-	for _, word := range words {
-		if word == "" {
+	// Skip allows us to skip repeated, non-matching rune output
+	skip := false
+	var out string
+	for _, r := range str {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			if !skip && len(out) > 0 {
+				out += "."
+			}
+			skip = true
 			continue
 		}
-
-		if result.Len() > 0 {
-			result.WriteString(".")
-		}
-
-		result.WriteString(word)
+		skip = false
+		out += strings.ToLower(string(r))
 	}
-
-	if result.Len() == 0 {
-		return "unknown"
-	}
-
-	return result.String()
+	return strings.TrimRight(out, "_.")
 }

--- a/tools/inflector/inflector_test.go
+++ b/tools/inflector/inflector_test.go
@@ -134,20 +134,33 @@ func TestUsernamify(t *testing.T) {
 		val      string
 		expected string
 	}{
-		{"", "unknown"},
-		{"  ", "unknown"},
-		{"!@#$%^", "unknown"},
-		{"...", "unknown"},
-		{"_", "_"}, // underscore is valid word character
+		{"", ""},
+		{"  ", ""},
+		{"!@#$%^", ""},
+		{"...", ""},
+		{"_", ""},
 		{"John Doe", "john.doe"},
 		{"John_Doe", "john_doe"},
 		{".a!b@c#d$e%123. ", "a.b.c.d.e.123"},
 		{"Hello,    world", "hello.world"},
+		{"Hello, 世界", "hello.世界"},
 	}
 
 	for i, scenario := range scenarios {
 		if result := inflector.Usernamify(scenario.val); result != scenario.expected {
 			t.Errorf("(%d) Expected %q, got %q", i, scenario.expected, result)
+		}
+	}
+}
+
+func BenchmarkUsernamify(b *testing.B) {
+	input := ".a!b@c#d$e%123 John "
+	want := "a.b.c.d.e.123.john"
+
+	for i := 0; i < b.N; i++ {
+		got := inflector.Usernamify(input)
+		if got != want {
+			b.Fatalf("got: %q, want: %q", got, want)
 		}
 	}
 }


### PR DESCRIPTION
There is often little reason to use regex in Go with string parsing since iterating over bytes or runes is built into the language. I saw the inflector package and realized the code could be much faster if operating directly on the underlying string. Turns out, it's about twice as fast and uses less than half the memory, there is still room for improvement.

```
BenchmarkUsernamify-old   	  530571	      2108 ns/op	     836 B/op	      15 allocs/op
BenchmarkUsernamify-new   	 1209289	      1140 ns/op	     280 B/op	      31 allocs/op
```

Please note, this is a change in API from the original `inflector.Usernamify` which returned unexpected magic constants ("unknown") instead of empty string for invalid input. Furthermore, the entire unicode letter space is now supported for usernames. This might not be desired, but is an improvement for global projects.
