### PR TITLE
Allow admin credentials to be passed via command options

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -235,7 +235,7 @@ func promptCreateAdmin(app core.App) error {
 			Prompt: &survey.Password{Message: "Pass (min 10 chars):"},
 			Validate: func(val any) error {
 				if str, ok := val.(string); !ok || len(str) < 10 {
-					return errors.New("The password must be at least 10 characters.")
+					return errors.New("the password must be at least 10 characters")
 				}
 				return nil
 			},


### PR DESCRIPTION
**Description**: This PR allows the user to pass admin credentials to create an admin if none are created when we first run the server.

**Problem this PR solves**: If someone is deploying or self hosting this with some automated script then they can't get the server running with simple steps.

**Advantages**: Now we can automate deploying by simply passing the credentials. For example creating a docker image and hosting the service using docker image

**Current Behaviour**: 
Now we run server by `./pocketbase serve` and it prompts to give email and password. Also unfortunately we can use piping or here strings or dochere etc., to pass the values to interactive promt. This will force the user to create admin once before deploying and reduces the scope of automation

**Behaviour after merge**:
We can just do `./pocketbase serve --admin.email test@example.com --admin.password 12a&wd1#eqwQ` and we can smoothly run server by automation.

> Though the recommended way to pass the credentials is by using env vars. Ex: `./pocketbase serve --admin.email $ADMIN_EMAIL --admin.password $ADMIN_PASSWORD`