### PR TITLE
fix migrations register in framework mode

### DIFF
--- a/migrations/1640988000_init.go
+++ b/migrations/1640988000_init.go
@@ -3,6 +3,8 @@ package migrations
 
 import (
 	"fmt"
+	"path/filepath"
+	"runtime"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/daos"
@@ -20,7 +22,14 @@ func Register(
 	down func(db dbx.Builder) error,
 	optFilename ...string,
 ) {
-	AppMigrations.Register(up, down, optFilename...)
+	var optFiles []string
+	if len(optFilename) > 0 {
+		optFiles = optFilename
+	} else {
+		_, path, _, _ := runtime.Caller(1)
+		optFiles = append(optFiles, filepath.Base(path))
+	}
+	AppMigrations.Register(up, down, optFiles...)
 }
 
 func init() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix:

Migration won't be registered if you don't provide `optFilename` currently in framework mode when you create migration.

## What is the current behavior?

Path would be `1640988000_init.go` for all migration files you try to register.

## What is the new behavior?

Now we add optFilename in `Register` function in `1640988000_init.go` if it is not provided in migration itself.
