### PR TITLE
Change timing of record init for RecordUpsertPanel

### DIFF
--- a/ui/src/components/base/OverlayPanel.svelte
+++ b/ui/src/components/base/OverlayPanel.svelte
@@ -86,6 +86,8 @@
             oldFocusedElem = document.activeElement;
             wrapper?.focus();
             dispatch("show");
+            await tick();
+            dispatch("updateInitRecord");
         } else {
             clearTimeout(contentScrollThrottle);
             oldFocusedElem?.focus();

--- a/ui/src/components/records/RecordUpsertPanel.svelte
+++ b/ui/src/components/records/RecordUpsertPanel.svelte
@@ -57,13 +57,16 @@
         return recordPanel?.hide();
     }
 
+    export function updateInitRecord() {
+        initialFormHash = calculateFormHash(record);
+    }
+
     function load(model) {
         setErrors({}); // reset errors
         original = model || {};
         record = model?.clone ? model.clone() : new Record();
         uploadedFilesMap = {};
         deletedFileIndexesMap = {};
-        initialFormHash = calculateFormHash(record);
     }
 
     function calculateFormHash(m) {
@@ -180,6 +183,7 @@
     }}
     on:hide
     on:show
+    on:updateInitRecord={updateInitRecord}
 >
     <svelte:fragment slot="header">
         <h4>


### PR DESCRIPTION
Thanks for the great project!
When adding new records to a collection, if the preset fields contain a 'file' field. The user will get a reminder saying that the user may have unsaved changes even though nothing has changed.
<img width="1144" alt="image" src="https://user-images.githubusercontent.com/15627635/178500993-5b37d6e4-3482-4af9-ae29-cc8dc0b64ce6.png">

I changed the timing of the record initialization and this might help with it.
Do you mind taking a look at this pr at your convenience? Thank you so much in advance!