### PR TITLE
Build instructions for no golang devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ Running/building the application is the same as for any other Go program, aka. j
 
 **PocketBase embeds SQLite, but doesn't require CGO.**
 
-If CGO is enabled, it will use [mattn/go-sqlite3](https://pkg.go.dev/github.com/mattn/go-sqlite3) driver, otherwise - [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite).
+If CGO is enabled, it will use [mattn/go-sqlite3](https://pkg.go.dev/github.com/mattn/go-sqlite3) driver, otherwise - [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite). You can enable and disable CGO by setting the `CGO_ENABLED` enviroment variable to `1` or `0` respectively. 
 
 Enable CGO only if you really need to squeeze the read/write query performance at the expense of complicating cross compilation.
+
+To build the minimal standalone executable, like the prebuilt ones in the releases page, you can simply run `go build` inside the `examples/base` directory.
 
 ### Testing
 


### PR DESCRIPTION
## Before explaining the changes

I just want to take the opportunity to say that I found this project in my daily.dev new tab page a day after I thought I needed something like this for a quick prototype project.

I loved the minimal and clean design of the admin ui and the whole project idea ❤ Keep doing a good work!

## Situation

I nearly don't have practical experience with golang. 

I wanted to run the minimal standalone executable in an old raspberry pi 3 b+ (32 bits) so I needed to build the executable for that architecture.

I cloned the repo and tried to do `go build`. But a "gcc not found" error appeared and I supposed it was because it was trying to use cgo but I didn't know how to disable it.

After disabling it, I tried to do  `go build` again but no executable was produced. My interpretation from the current readme was that by simply running that you get the executable I needed to google to understand why the executable was not being produced and search manually for a file with the package `main` in the repository.

## Changes

- Improves the readme to help people without golang knowledge to generate the minimal executable file.
  - Added a clarification about how to enable and disable cgo.
  - Added a clarification saying where to run `go build` to get a minimal executable like the prebuilt ones.