### PR TITLE
fix field name input issue

### DIFF
--- a/ui/src/components/collections/FieldAccordion.svelte
+++ b/ui/src/components/collections/FieldAccordion.svelte
@@ -221,9 +221,13 @@
                         spellcheck="false"
                         autofocus={!field.id}
                         value={field.name}
-                        on:input={(e) => {
+                        on:blur={(e) => {
                             field.name = normalizeFieldName(e.target.value);
                             e.target.value = field.name;
+                        }}
+                        on:input={(e) => {
+                            const name = CommonHelper.slugify(e.target.value);
+                            e.target.value = name; 
                         }}
                     />
                 </Field>


### PR DESCRIPTION
When there is already a `file` field in schama, adding a filename field from the admin panel will be automatically recognized as a duplicate field by the `normalizeFieldName` function, so `filename` will become `file1name`.

https://github.com/pocketbase/pocketbase/blob/1095637bcd9aaf3901bdc075dc430a1003efaa8d/ui/src/components/collections/FieldAccordion.svelte#L91-L100
