### PR TITLE
Fix for all migrations reverted when doing `migrate down 1`

### DIFF
--- a/tools/migrate/runner.go
+++ b/tools/migrate/runner.go
@@ -220,6 +220,7 @@ func (r *Runner) Down(toRevertCount int) ([]string, error) {
 				return fmt.Errorf("Failed to save reverted migration info for %s: %w", m.file, err)
 			}
 
+			totalReverted++
 			applied = append(applied, m.file)
 		}
 

--- a/tools/migrate/runner.go
+++ b/tools/migrate/runner.go
@@ -194,11 +194,9 @@ func (r *Runner) Up() ([]string, error) {
 //
 // On success returns list with the reverted migrations file names.
 func (r *Runner) Down(toRevertCount int) ([]string, error) {
-	applied := []string{}
+	reverted := make([]string, 0, toRevertCount)
 
 	err := r.db.Transactional(func(tx *dbx.Tx) error {
-		totalReverted := 0
-
 		for i := len(r.migrationsList.Items()) - 1; i >= 0; i-- {
 			m := r.migrationsList.Item(i)
 
@@ -208,7 +206,7 @@ func (r *Runner) Down(toRevertCount int) ([]string, error) {
 			}
 
 			// revert limit reached
-			if toRevertCount-totalReverted <= 0 {
+			if toRevertCount-len(reverted) <= 0 {
 				break
 			}
 
@@ -220,8 +218,7 @@ func (r *Runner) Down(toRevertCount int) ([]string, error) {
 				return fmt.Errorf("Failed to save reverted migration info for %s: %w", m.file, err)
 			}
 
-			totalReverted++
-			applied = append(applied, m.file)
+			reverted = append(reverted, m.file)
 		}
 
 		return nil
@@ -230,7 +227,7 @@ func (r *Runner) Down(toRevertCount int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return applied, nil
+	return reverted, nil
 }
 
 func (r *Runner) createMigrationsTable() error {

--- a/tools/migrate/runner_test.go
+++ b/tools/migrate/runner_test.go
@@ -104,7 +104,8 @@ func TestRunnerUpAndDown(t *testing.T) {
 
 	// Down()
 	// ---
-	if _, err := r.Down(2); err != nil {
+	// revert one migration
+	if _, err := r.Down(1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -112,8 +113,12 @@ func TestRunnerUpAndDown(t *testing.T) {
 		t.Fatal("Didn't expect 3_test to be reverted.")
 	}
 
-	if !test1DownCalled || !test2DownCalled {
-		t.Fatalf("Expected 1_test and 2_test to be reverted, got %v and %v", test1DownCalled, test2DownCalled)
+	if !test2DownCalled {
+		t.Fatal("Expected 2_test to be reverted.")
+	}
+
+	if test1DownCalled {
+		t.Fatal("Didn't expect 1_test to be reverted.")
 	}
 }
 


### PR DESCRIPTION
This should fix #161 

Debated using `len(applied)` in the if statement, but didn't want to remove `totalReverted` since I'm not too familiar.