### PR TITLE
use read-only scopes for github auth

### DIFF
--- a/tools/auth/github.go
+++ b/tools/auth/github.go
@@ -21,7 +21,7 @@ type Github struct {
 // NewGithubProvider creates new Github provider instance with some defaults.
 func NewGithubProvider() *Github {
 	return &Github{&baseProvider{
-		scopes:     []string{"user"},
+		scopes:     []string{"read:user", "user:email"},
 		authUrl:    "https://github.com/login/oauth/authorize",
 		tokenUrl:   "https://github.com/login/oauth/access_token",
 		userApiUrl: "https://api.github.com/user",


### PR DESCRIPTION
According to github's doc, `user` scope includes write access to profile info.
Read-only scope would be sufficient for this auth flow.

ref: https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps