### PR TITLE
added armv7 on linux as a build target

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,13 +20,20 @@ builds:
     goarch:
       - amd64
       - arm64
+      - arm
+    goarm:
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm
+      - goos: darwin
+        goarch: arm
 
 release:
   draft: true
 
 archives:
-  -
-    format: zip
+  - format: zip
     files:
       - LICENSE*
       - CHANGELOG*
@@ -35,7 +42,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  name_template: '{{ incpatch .Version }}-next'
 
 changelog:
   sort: asc


### PR DESCRIPTION
Added `armv7` for Linux as a build target to support distribution on Raspberry Pi 2 and above.