### PR TITLE
Set `Id` when save model as ColumnValueMapper

### DIFF
--- a/daos/base.go
+++ b/daos/base.go
@@ -195,6 +195,7 @@ func (dao *Dao) create(m models.Model) error {
 
 	if v, ok := any(m).(models.ColumnValueMapper); ok {
 		dataMap := v.ColumnValueMap()
+		dataMap["id"] = m.GetId() //prevent Mapper not return 'id'
 
 		_, err := dao.db.Insert(m.TableName(), dataMap).Execute()
 		if err != nil {

--- a/daos/base_test.go
+++ b/daos/base_test.go
@@ -158,6 +158,41 @@ func TestDaoSaveCreate(t *testing.T) {
 	}
 }
 
+type TestAdminMapper struct {
+	models.Admin
+}
+
+func (m *TestAdminMapper) ColumnValueMap() map[string]any {
+	return map[string]any{
+		"email":    m.Email,
+		"avatar":   m.Avatar,
+		"tokenKey": m.TokenKey,
+		"passwordHash":m.PasswordHash,
+	}
+}
+
+func TestDaoSaveCreateWithMapper(t *testing.T) {
+	testApp, _ := tests.NewTestApp()
+	defer testApp.Cleanup()
+
+	model := &models.Admin{}
+	model.Email = "test_new@example.com"
+	model.Avatar = 8
+	mapper := &TestAdminMapper{
+		*model,
+	}
+	if err := testApp.Dao().Save(mapper); err != nil {
+		t.Fatal(err)
+	}
+
+	// refresh
+	_, err := testApp.Dao().FindAdminByEmail("test_new@example.com")
+
+	if err != nil {
+		t.Fatalf("Expected to get saved admin, failed with error %v", err)
+	}
+}
+
 func TestDaoSaveUpdate(t *testing.T) {
 	testApp, _ := tests.NewTestApp()
 	defer testApp.Cleanup()


### PR DESCRIPTION
I'm using `ColumnValueMapper` to save model. Accidentally find the map not contains 'id' is still saved, but failed to get it back.
Hope this PR can prevent this scenario.