### PR TITLE
Added Discord OAuth2 provider and fixed code_verifier generation

### DIFF
--- a/apis/user.go
+++ b/apis/user.go
@@ -129,7 +129,7 @@ func (api *userApi) authMethods(c echo.Context) error {
 		}
 
 		state := security.RandomString(30)
-		codeVerifier := security.RandomString(30)
+		codeVerifier := security.RandomString(43)
 		codeChallenge := security.S256Challenge(codeVerifier)
 		codeChallengeMethod := "S256"
 		result.AuthProviders = append(result.AuthProviders, providerInfo{

--- a/core/settings.go
+++ b/core/settings.go
@@ -35,6 +35,7 @@ type Settings struct {
 	FacebookAuth AuthProviderConfig `form:"facebookAuth" json:"facebookAuth"`
 	GithubAuth   AuthProviderConfig `form:"githubAuth" json:"githubAuth"`
 	GitlabAuth   AuthProviderConfig `form:"gitlabAuth" json:"gitlabAuth"`
+	DiscordAuth  AuthProviderConfig `form:"discordAuth" json:"discordAuth"`
 }
 
 // NewSettings creates and returns a new default Settings instance.
@@ -106,6 +107,10 @@ func NewSettings() *Settings {
 			Enabled:            false,
 			AllowRegistrations: true,
 		},
+		DiscordAuth: AuthProviderConfig{
+			Enabled:            false,
+			AllowRegistrations: true,
+		},
 	}
 }
 
@@ -130,6 +135,7 @@ func (s *Settings) Validate() error {
 		validation.Field(&s.FacebookAuth),
 		validation.Field(&s.GithubAuth),
 		validation.Field(&s.GitlabAuth),
+		validation.Field(&s.DiscordAuth),
 	)
 }
 
@@ -178,6 +184,7 @@ func (s *Settings) RedactClone() (*Settings, error) {
 		&clone.FacebookAuth.ClientSecret,
 		&clone.GithubAuth.ClientSecret,
 		&clone.GitlabAuth.ClientSecret,
+		&clone.DiscordAuth.ClientSecret,
 	}
 
 	// mask all sensitive fields
@@ -201,6 +208,7 @@ func (s *Settings) NamedAuthProviderConfigs() map[string]AuthProviderConfig {
 		auth.NameFacebook: s.FacebookAuth,
 		auth.NameGithub:   s.GithubAuth,
 		auth.NameGitlab:   s.GitlabAuth,
+		auth.NameDiscord:  s.DiscordAuth,
 	}
 }
 

--- a/core/settings_test.go
+++ b/core/settings_test.go
@@ -37,6 +37,8 @@ func TestSettingsValidate(t *testing.T) {
 	s.GithubAuth.ClientId = ""
 	s.GitlabAuth.Enabled = true
 	s.GitlabAuth.ClientId = ""
+	s.DiscordAuth.Enabled = true
+	s.DiscordAuth.ClientId = ""
 
 	// check if Validate() is triggering the members validate methods.
 	err := s.Validate()
@@ -60,6 +62,7 @@ func TestSettingsValidate(t *testing.T) {
 		`"facebookAuth":{`,
 		`"githubAuth":{`,
 		`"gitlabAuth":{`,
+		`"discordAuth":{`,
 	}
 
 	errBytes, _ := json.Marshal(err)
@@ -98,6 +101,8 @@ func TestSettingsMerge(t *testing.T) {
 	s2.GithubAuth.ClientId = "github_test"
 	s2.GitlabAuth.Enabled = true
 	s2.GitlabAuth.ClientId = "gitlab_test"
+	s2.DiscordAuth.Enabled = true
+	s2.DiscordAuth.ClientId = "gitlab_test"
 
 	if err := s1.Merge(s2); err != nil {
 		t.Fatal(err)
@@ -163,6 +168,7 @@ func TestSettingsRedactClone(t *testing.T) {
 	s1.FacebookAuth.ClientSecret = "test123"
 	s1.GithubAuth.ClientSecret = "test123"
 	s1.GitlabAuth.ClientSecret = "test123"
+	s1.DiscordAuth.ClientSecret = "test123"
 
 	s2, err := s1.RedactClone()
 	if err != nil {
@@ -174,7 +180,7 @@ func TestSettingsRedactClone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `{"meta":{"appName":"test123","appUrl":"http://localhost:8090","hideControls":false,"senderName":"Support","senderAddress":"support@example.com","verificationTemplate":{"body":"\u003cp\u003eHello,\u003c/p\u003e\n\u003cp\u003eThank you for joining us at {APP_NAME}.\u003c/p\u003e\n\u003cp\u003eClick on the button below to verify your email address.\u003c/p\u003e\n\u003cp\u003e\n  \u003ca class=\"btn\" href=\"{ACTION_URL}\" target=\"_blank\" rel=\"noopener\"\u003eVerify\u003c/a\u003e\n\u003c/p\u003e\n\u003cp\u003e\n  Thanks,\u003cbr/\u003e\n  {APP_NAME} team\n\u003c/p\u003e","subject":"Verify your {APP_NAME} email","actionUrl":"{APP_URL}/_/#/users/confirm-verification/{TOKEN}"},"resetPasswordTemplate":{"body":"\u003cp\u003eHello,\u003c/p\u003e\n\u003cp\u003eClick on the button below to reset your password.\u003c/p\u003e\n\u003cp\u003e\n  \u003ca class=\"btn\" href=\"{ACTION_URL}\" target=\"_blank\" rel=\"noopener\"\u003eReset password\u003c/a\u003e\n\u003c/p\u003e\n\u003cp\u003e\u003ci\u003eIf you didn't ask to reset your password, you can ignore this email.\u003c/i\u003e\u003c/p\u003e\n\u003cp\u003e\n  Thanks,\u003cbr/\u003e\n  {APP_NAME} team\n\u003c/p\u003e","subject":"Reset your {APP_NAME} password","actionUrl":"{APP_URL}/_/#/users/confirm-password-reset/{TOKEN}"},"confirmEmailChangeTemplate":{"body":"\u003cp\u003eHello,\u003c/p\u003e\n\u003cp\u003eClick on the button below to confirm your new email address.\u003c/p\u003e\n\u003cp\u003e\n  \u003ca class=\"btn\" href=\"{ACTION_URL}\" target=\"_blank\" rel=\"noopener\"\u003eConfirm new email\u003c/a\u003e\n\u003c/p\u003e\n\u003cp\u003e\u003ci\u003eIf you didn't ask to change your email address, you can ignore this email.\u003c/i\u003e\u003c/p\u003e\n\u003cp\u003e\n  Thanks,\u003cbr/\u003e\n  {APP_NAME} team\n\u003c/p\u003e","subject":"Confirm your {APP_NAME} new email address","actionUrl":"{APP_URL}/_/#/users/confirm-email-change/{TOKEN}"}},"logs":{"maxDays":7},"smtp":{"enabled":false,"host":"smtp.example.com","port":587,"username":"","password":"******","tls":true},"s3":{"enabled":false,"bucket":"","region":"","endpoint":"","accessKey":"","secret":"******","forcePathStyle":false},"adminAuthToken":{"secret":"******","duration":1209600},"adminPasswordResetToken":{"secret":"******","duration":1800},"userAuthToken":{"secret":"******","duration":1209600},"userPasswordResetToken":{"secret":"******","duration":1800},"userEmailChangeToken":{"secret":"******","duration":1800},"userVerificationToken":{"secret":"******","duration":604800},"emailAuth":{"enabled":true,"exceptDomains":null,"onlyDomains":null,"minPasswordLength":8},"googleAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"},"facebookAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"},"githubAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"},"gitlabAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"}}`
+	expected := `{"meta":{"appName":"test123","appUrl":"http://localhost:8090","hideControls":false,"senderName":"Support","senderAddress":"support@example.com","verificationTemplate":{"body":"\u003cp\u003eHello,\u003c/p\u003e\n\u003cp\u003eThank you for joining us at {APP_NAME}.\u003c/p\u003e\n\u003cp\u003eClick on the button below to verify your email address.\u003c/p\u003e\n\u003cp\u003e\n  \u003ca class=\"btn\" href=\"{ACTION_URL}\" target=\"_blank\" rel=\"noopener\"\u003eVerify\u003c/a\u003e\n\u003c/p\u003e\n\u003cp\u003e\n  Thanks,\u003cbr/\u003e\n  {APP_NAME} team\n\u003c/p\u003e","subject":"Verify your {APP_NAME} email","actionUrl":"{APP_URL}/_/#/users/confirm-verification/{TOKEN}"},"resetPasswordTemplate":{"body":"\u003cp\u003eHello,\u003c/p\u003e\n\u003cp\u003eClick on the button below to reset your password.\u003c/p\u003e\n\u003cp\u003e\n  \u003ca class=\"btn\" href=\"{ACTION_URL}\" target=\"_blank\" rel=\"noopener\"\u003eReset password\u003c/a\u003e\n\u003c/p\u003e\n\u003cp\u003e\u003ci\u003eIf you didn't ask to reset your password, you can ignore this email.\u003c/i\u003e\u003c/p\u003e\n\u003cp\u003e\n  Thanks,\u003cbr/\u003e\n  {APP_NAME} team\n\u003c/p\u003e","subject":"Reset your {APP_NAME} password","actionUrl":"{APP_URL}/_/#/users/confirm-password-reset/{TOKEN}"},"confirmEmailChangeTemplate":{"body":"\u003cp\u003eHello,\u003c/p\u003e\n\u003cp\u003eClick on the button below to confirm your new email address.\u003c/p\u003e\n\u003cp\u003e\n  \u003ca class=\"btn\" href=\"{ACTION_URL}\" target=\"_blank\" rel=\"noopener\"\u003eConfirm new email\u003c/a\u003e\n\u003c/p\u003e\n\u003cp\u003e\u003ci\u003eIf you didn't ask to change your email address, you can ignore this email.\u003c/i\u003e\u003c/p\u003e\n\u003cp\u003e\n  Thanks,\u003cbr/\u003e\n  {APP_NAME} team\n\u003c/p\u003e","subject":"Confirm your {APP_NAME} new email address","actionUrl":"{APP_URL}/_/#/users/confirm-email-change/{TOKEN}"}},"logs":{"maxDays":7},"smtp":{"enabled":false,"host":"smtp.example.com","port":587,"username":"","password":"******","tls":true},"s3":{"enabled":false,"bucket":"","region":"","endpoint":"","accessKey":"","secret":"******","forcePathStyle":false},"adminAuthToken":{"secret":"******","duration":1209600},"adminPasswordResetToken":{"secret":"******","duration":1800},"userAuthToken":{"secret":"******","duration":1209600},"userPasswordResetToken":{"secret":"******","duration":1800},"userEmailChangeToken":{"secret":"******","duration":1800},"userVerificationToken":{"secret":"******","duration":604800},"emailAuth":{"enabled":true,"exceptDomains":null,"onlyDomains":null,"minPasswordLength":8},"googleAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"},"facebookAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"},"githubAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"},"gitlabAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"},"discordAuth":{"enabled":false,"allowRegistrations":true,"clientSecret":"******"}}`
 
 	if encodedStr := string(encoded); encodedStr != expected {
 		t.Fatalf("Expected %v, got \n%v", expected, encodedStr)
@@ -189,6 +195,7 @@ func TestNamedAuthProviderConfigs(t *testing.T) {
 	s.GithubAuth.ClientId = "github_test"
 	s.GitlabAuth.ClientId = "gitlab_test"
 	s.GitlabAuth.Enabled = true
+	s.DiscordAuth.ClientId = "discord_test"
 
 	result := s.NamedAuthProviderConfigs()
 
@@ -197,7 +204,7 @@ func TestNamedAuthProviderConfigs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := `{"facebook":{"enabled":false,"allowRegistrations":true,"clientId":"facebook_test"},"github":{"enabled":false,"allowRegistrations":true,"clientId":"github_test"},"gitlab":{"enabled":true,"allowRegistrations":true,"clientId":"gitlab_test"},"google":{"enabled":false,"allowRegistrations":true,"clientId":"google_test"}}`
+	expected := `{"discord":{"enabled":false,"allowRegistrations":true,"clientId":"discord_test"},"facebook":{"enabled":false,"allowRegistrations":true,"clientId":"facebook_test"},"github":{"enabled":false,"allowRegistrations":true,"clientId":"github_test"},"gitlab":{"enabled":true,"allowRegistrations":true,"clientId":"gitlab_test"},"google":{"enabled":false,"allowRegistrations":true,"clientId":"google_test"}}`
 
 	if encodedStr := string(encoded); encodedStr != expected {
 		t.Fatalf("Expected the same serialization, got %v", encodedStr)

--- a/core/settings_test.go
+++ b/core/settings_test.go
@@ -102,7 +102,7 @@ func TestSettingsMerge(t *testing.T) {
 	s2.GitlabAuth.Enabled = true
 	s2.GitlabAuth.ClientId = "gitlab_test"
 	s2.DiscordAuth.Enabled = true
-	s2.DiscordAuth.ClientId = "gitlab_test"
+	s2.DiscordAuth.ClientId = "discord_test"
 
 	if err := s1.Merge(s2); err != nil {
 		t.Fatal(err)

--- a/tools/auth/auth.go
+++ b/tools/auth/auth.go
@@ -90,6 +90,8 @@ func NewProviderByName(name string) (Provider, error) {
 		return NewGithubProvider(), nil
 	case NameGitlab:
 		return NewGitlabProvider(), nil
+	case NameDiscord:
+		return NewDiscordProvider(), nil
 	default:
 		return nil, errors.New("Missing provider " + name)
 	}

--- a/tools/auth/auth_test.go
+++ b/tools/auth/auth_test.go
@@ -54,4 +54,13 @@ func TestNewProviderByName(t *testing.T) {
 	if _, ok := p.(*auth.Gitlab); !ok {
 		t.Error("Expected to be instance of *auth.Gitlab")
 	}
+
+	// discord
+	p, err = auth.NewProviderByName(auth.NameDiscord)
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+	if _, ok := p.(*auth.Discord); !ok {
+		t.Error("Expected to be instance of *auth.Discord")
+	}
 }

--- a/tools/auth/discord.go
+++ b/tools/auth/discord.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"fmt"
+
+	"golang.org/x/oauth2"
+)
+
+var _ Provider = (*Discord)(nil)
+
+// NameDiscord is the unique name of the Discord provider.
+const NameDiscord string = "discord"
+
+// Discord allows authentication via Discord OAuth2.
+type Discord struct {
+	*baseProvider
+}
+
+// NewDiscordProvider creates a new Discord provider instance with some defaults.
+func NewDiscordProvider() *Discord {
+	// https://discord.com/developers/docs/topics/oauth2
+	// https://discord.com/developers/docs/resources/user#get-current-user
+	return &Discord{&baseProvider{
+		scopes:     []string{"identify", "email"},
+		authUrl:    "https://discord.com/api/oauth2/authorize",
+		tokenUrl:   "https://discord.com/api/oauth2/token",
+		userApiUrl: "https://discord.com/api/users/@me",
+	}}
+}
+
+// FetchAuthUser returns an AuthUser instance from Discord's user api.
+func (p *Discord) FetchAuthUser(token *oauth2.Token) (*AuthUser, error) {
+	// https://discord.com/developers/docs/resources/user#user-object
+	rawData := struct {
+		Id            string `json:"id"`
+		Username      string `json:"username"`
+		Discriminator string `json:"discriminator"`
+		Email         string `json:"email"`
+		Avatar        string `json:"avatar"`
+	}{}
+
+	if err := p.FetchRawUserData(token, &rawData); err != nil {
+		return nil, err
+	}
+
+	// Build a full avatar URL using the avatar hash provided in the API response
+	// https://discord.com/developers/docs/reference#image-formatting
+	avatarUrl := fmt.Sprintf("https://cdn.discordapp.com/avatars/%s/%s.png", rawData.Id, rawData.Avatar)
+
+	// Concatenate the user's username and discriminator into a single username string
+	username := fmt.Sprintf("%s#%s", rawData.Username, rawData.Discriminator)
+
+	user := &AuthUser{
+		Id:        rawData.Id,
+		Name:      username,
+		Email:     rawData.Email,
+		AvatarUrl: avatarUrl,
+	}
+
+	return user, nil
+}

--- a/tools/auth/discord.go
+++ b/tools/auth/discord.go
@@ -8,6 +8,8 @@ import (
 
 var _ Provider = (*Discord)(nil)
 
+var discordScopes = []string{"identify", "email"}
+
 // NameDiscord is the unique name of the Discord provider.
 const NameDiscord string = "discord"
 
@@ -21,7 +23,7 @@ func NewDiscordProvider() *Discord {
 	// https://discord.com/developers/docs/topics/oauth2
 	// https://discord.com/developers/docs/resources/user#get-current-user
 	return &Discord{&baseProvider{
-		scopes:     []string{"identify", "email"},
+		scopes:     discordScopes,
 		authUrl:    "https://discord.com/api/oauth2/authorize",
 		tokenUrl:   "https://discord.com/api/oauth2/token",
 		userApiUrl: "https://discord.com/api/users/@me",

--- a/ui/src/components/settings/PageAuthProviders.svelte
+++ b/ui/src/components/settings/PageAuthProviders.svelte
@@ -63,7 +63,7 @@
             emailAuth: Object.assign({ enabled: true }, data.emailAuth),
         };
 
-        const providers = ["googleAuth", "facebookAuth", "githubAuth", "gitlabAuth"];
+        const providers = ["googleAuth", "facebookAuth", "githubAuth", "gitlabAuth", "discordAuth"];
         for (const provider of providers) {
             formSettings[provider] = Object.assign(
                 { enabled: false, allowRegistrations: true },
@@ -130,6 +130,13 @@
                         icon="ri-gitlab-line"
                         showSelfHostedFields
                         bind:config={formSettings.gitlabAuth}
+                    />
+                    <AuthProviderAccordion
+                        single
+                        key="discordAuth"
+                        title="Discord"
+                        icon="ri-discord-line"
+                        bind:config={formSettings.discordAuth}
                     />
                 </div>
 


### PR DESCRIPTION
This adds support for Discord OAuth2 for user authentication. Most of the new code is just copied from the existing providers, with the exception of a fix for the `code_verifier` parameter generation. For this to work with Discord's OAuth2 flow, the `code_verifier` parameter needs to be at least 43 characters long (don't ask how long it took me to figure that out).

In addition to adding a new provider, this change brings the client flow into compliance with section 4.1 of [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636#section-4.1). It's likely that this wasn't an issue with the other OAuth2 providers because none of them were compliant with this part of the spec.

### Screenshot
![image](https://user-images.githubusercontent.com/49822414/185778264-d570004d-42e9-4bb4-a419-5a22a27610ee.png)

**Cross-references for anyone else spending hours on this bug:**
https://github.com/golang/oauth2/issues/581
https://github.com/discord/discord-api-docs/issues/5254#issuecomment-1221476617