### PR TITLE
Fix auth issue when creating new records

### DIFF
--- a/apis/base.go
+++ b/apis/base.go
@@ -134,7 +134,7 @@ func StaticDirectoryHandler(fileSystem fs.FS, disablePathUnescaping bool) echo.H
 }
 
 // bindStaticAdminUI registers the endpoints that serves the static admin UI.
-func bindStaticAdminUI(app core.App, e *echo.Echo) error {
+func bindStaticAdminUI(app core.App, e *echo.Echo) {
 	// redirect to trailing slash to ensure that relative urls will still work properly
 	e.GET(
 		strings.TrimRight(trailedAdminPath, "/"),
@@ -152,7 +152,7 @@ func bindStaticAdminUI(app core.App, e *echo.Echo) error {
 		middleware.Gzip(),
 	)
 
-	return nil
+	return
 }
 
 const totalAdminsCacheKey = "totalAdmins"

--- a/models/record.go
+++ b/models/record.go
@@ -246,7 +246,7 @@ func (m *Record) PublicExport() map[string]any {
 // MarshalJSON implements the [json.Marshaler] interface.
 //
 // Only the data exported by `PublicExport()` will be serialized.
-func (m Record) MarshalJSON() ([]byte, error) {
+func (m *Record) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m.PublicExport())
 }
 

--- a/tools/inflector/inflector.go
+++ b/tools/inflector/inflector.go
@@ -8,6 +8,13 @@ import (
 
 var columnifyRemoveRegex = regexp.MustCompile(`[^\w\.\*\-\_\@\#]+`)
 var snakecaseSplitRegex = regexp.MustCompile(`[\W_]+`)
+var safeIDRemoveRegex = regexp.MustCompile(`[^0-9a-zA-Z\-]`)
+
+// SafeID strips out invalid id characters
+// uuids and contiguous letters are allowed.
+func SafeID(str string) string {
+	return safeIDRemoveRegex.ReplaceAllString(str, "")
+}
 
 // UcFirst converts the first character of a string into uppercase.
 func UcFirst(str string) string {

--- a/tools/inflector/inflector_test.go
+++ b/tools/inflector/inflector_test.go
@@ -6,6 +6,32 @@ import (
 	"github.com/pocketbase/pocketbase/tools/inflector"
 )
 
+func TestSafeID(t *testing.T) {
+	scenarios := []struct {
+		val      string
+		expected string
+	}{
+		{"", ""},
+		{"   ", ""},
+		{"123", "123"},
+		{"Test.", "Test"},
+		{" test ", "test"},
+		{"test1.test2", "test1test2"},
+		{"@test!abc", "testabc"},
+		{"#test?abc", "testabc"},
+		{"123test(123)#", "123test123"},
+		{"test1--test2", "test1--test2"},
+		{"01bc82c4-4fae-45e7-aaa7-9be704179e64", "01bc82c4-4fae-45e7-aaa7-9be704179e64"},
+		{`'\n;'`, "n"},
+	}
+
+	for i, scenario := range scenarios {
+		if result := inflector.SafeID(scenario.val); result != scenario.expected {
+			t.Errorf("(%d) Expected %q, got %q", i, scenario.expected, result)
+		}
+	}
+}
+
 func TestUcFirst(t *testing.T) {
 	scenarios := []struct {
 		val      string

--- a/tools/list/list.go
+++ b/tools/list/list.go
@@ -2,13 +2,14 @@ package list
 
 import (
 	"encoding/json"
+	"github.com/pocketbase/pocketbase/tools/store"
 	"regexp"
 	"strings"
 
 	"github.com/spf13/cast"
 )
 
-var cachedPatterns = map[string]*regexp.Regexp{}
+var cachedPatterns = store.New(make(map[string]*regexp.Regexp, 50))
 
 // ExistInSlice checks whether a comparable element exists in a slice of the same type.
 func ExistInSlice[T comparable](item T, list []T) bool {
@@ -42,7 +43,7 @@ func ExistInSliceWithRegex(str string, list []string) bool {
 		}
 
 		// check for regex match
-		pattern, ok := cachedPatterns[field]
+		pattern, ok := cachedPatterns.MightGet(field)
 		if !ok {
 			var err error
 			pattern, err = regexp.Compile(field)
@@ -50,7 +51,7 @@ func ExistInSliceWithRegex(str string, list []string) bool {
 				continue
 			}
 			// "cache" the pattern to avoid compiling it every time
-			cachedPatterns[field] = pattern
+			cachedPatterns.Set(field, pattern)
 		}
 
 		if pattern != nil && pattern.MatchString(str) {

--- a/tools/store/store.go
+++ b/tools/store/store.go
@@ -41,6 +41,18 @@ func (s *Store[T]) Has(key string) bool {
 	return ok
 }
 
+// MightGet returns a single element value and a status of if the retrieve was successful
+//
+// If key is not set, the zero T value is returned along with a false.
+func (s *Store[T]) MightGet(key string) (T, bool) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	v, ok := s.data[key]
+
+	return v, ok
+}
+
 // Get returns a single element value from the store.
 //
 // If key is not set, the zero T value is returned.


### PR DESCRIPTION
When I was trying to design a role members table for a multi tenant thing I am working on I noticed an issue where if the incoming create request had the permissions I was looking for it would allow it. 
This PR adjusts the join to use a subquery which excludes the id of the test record. 

Not sure if this is structurally where something like this should exist. I am happy to make any changes or refactors. 