### PR TITLE
add spa flag to serve static files in spa mode

### DIFF
--- a/examples/base/main.go
+++ b/examples/base/main.go
@@ -24,6 +24,7 @@ func main() {
 	app := pocketbase.New()
 
 	var publicDirFlag string
+	var isSpa bool
 
 	// add "--publicDir" option flag
 	app.RootCmd.PersistentFlags().StringVar(
@@ -32,11 +33,16 @@ func main() {
 		defaultPublicDir(),
 		"the directory to serve static files",
 	)
+	app.RootCmd.PersistentFlags().BoolVar(
+		&isSpa,
+		"spa",
+		false,
+		"serve public dir files in spa mode",
+	)
 
 	app.OnBeforeServe().Add(func(e *core.ServeEvent) error {
 		// serves static files from the provided public dir (if exists)
-		e.Router.GET("/*", apis.StaticDirectoryHandler(os.DirFS(publicDirFlag), false))
-
+		e.Router.GET("/*", apis.StaticDirectoryHandler(os.DirFS(publicDirFlag), false, isSpa))
 		return nil
 	})
 


### PR DESCRIPTION
Added --spa as a flag to serve static files in spa mode.
This is useful if you use pocketbase pb_public dir to serve react, angular, vue or whatever spa framework you like. 
If in spa mode, the StaticDirectoryHandler falls back to index.html when the file is not found and contains no dot. 
For example, /deep/deep/link would fall back to index.html but /unknown.png would still return 404.

