### PR TITLE
Respect the EXIF auto orientation tag.

### DIFF
--- a/tools/filesystem/filesystem.go
+++ b/tools/filesystem/filesystem.go
@@ -272,7 +272,7 @@ func (s *System) CreateThumb(originalKey string, thumbKey, thumbSize string) err
 	defer r.Close()
 
 	// create imaging object from the origial reader
-	img, decodeErr := imaging.Decode(r)
+	img, decodeErr := imaging.Decode(r, imaging.AutoOrientation(true))
 	if decodeErr != nil {
 		return decodeErr
 	}


### PR DESCRIPTION
When uploading an image from a mobile device, the generated thumbnails are not rotated according to the EXIF tag. This results in thumbnails being potentially generated in the wrong orientation.

The [imaging package supports reading the EXIF tag](
https://github.com/disintegration/imaging#incorrect-image-orientation-after-processing-eg-an-image-appears-rotated-after-resizing), so adding support for it is a simple fix.
