### PR TITLE
Added health API endpoint

### DIFF
--- a/apis/base.go
+++ b/apis/base.go
@@ -92,7 +92,6 @@ func InitApi(app core.App) (*echo.Echo, error) {
 
 	// default routes
 	api := e.Group("/api")
-	defer bindHealthApi(app, api) // health check should always be initialized after everything else is done
 	bindSettingsApi(app, api)
 	bindAdminApi(app, api)
 	bindCollectionApi(app, api)
@@ -101,6 +100,7 @@ func InitApi(app core.App) (*echo.Echo, error) {
 	bindFileApi(app, api)
 	bindRealtimeApi(app, api)
 	bindLogsApi(app, api)
+	bindHealthApi(app, api) // health check should always be initialized after everything else is done
 
 	// trigger the custom BeforeServe hook for the created api router
 	// allowing users to further adjust its options or register new routes

--- a/apis/base.go
+++ b/apis/base.go
@@ -92,6 +92,7 @@ func InitApi(app core.App) (*echo.Echo, error) {
 
 	// default routes
 	api := e.Group("/api")
+	defer bindHealthApi(app, api) // health check should always be initialized after everything else is done
 	bindSettingsApi(app, api)
 	bindAdminApi(app, api)
 	bindCollectionApi(app, api)

--- a/apis/health.go
+++ b/apis/health.go
@@ -22,7 +22,6 @@ type healthApi struct {
 func (api *healthApi) healthCheck(c echo.Context) error {
 	payload := map[string]any{
 		"code":    http.StatusOK,
-		"status":  "ok",
 		"message": "API is healthy.",
 	}
 	return c.JSON(http.StatusOK, payload)

--- a/apis/health.go
+++ b/apis/health.go
@@ -1,0 +1,29 @@
+package apis
+
+import (
+	"github.com/labstack/echo/v5"
+	"github.com/pocketbase/pocketbase/core"
+	"net/http"
+)
+
+// bindHealthApi registers the health api endpoint.
+func bindHealthApi(app core.App, rg *echo.Group) {
+	api := healthApi{app: app}
+
+	subGroup := rg.Group("/health")
+	subGroup.GET("", api.healthCheck)
+}
+
+type healthApi struct {
+	app core.App
+}
+
+// healthCheck returns a 200 OK response if the server is healthy.
+func (api *healthApi) healthCheck(c echo.Context) error {
+	payload := map[string]any{
+		"code":    http.StatusOK,
+		"status":  "ok",
+		"message": "API is healthy.",
+	}
+	return c.JSON(http.StatusOK, payload)
+}

--- a/apis/health_test.go
+++ b/apis/health_test.go
@@ -1,0 +1,26 @@
+package apis_test
+
+import (
+	"github.com/pocketbase/pocketbase/tests"
+	"net/http"
+	"testing"
+)
+
+func TestHealthAPI(t *testing.T) {
+	scenarios := []tests.ApiScenario{
+		{
+			Name:           "health status returns 200",
+			Method:         http.MethodGet,
+			Url:            "/api/health",
+			ExpectedStatus: 200,
+			ExpectedContent: []string{
+				`"code":200`,
+				`"status":"ok"`,
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		scenario.Test(t)
+	}
+}

--- a/apis/health_test.go
+++ b/apis/health_test.go
@@ -15,7 +15,6 @@ func TestHealthAPI(t *testing.T) {
 			ExpectedStatus: 200,
 			ExpectedContent: []string{
 				`"code":200`,
-				`"status":"ok"`,
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds an `/api/health` endpoint.

It responds with a `200 OK` status and adds the following body:

```
{
  "code": 200,
  "message": "API is healthy.",
  "status": "ok"
}
``` 

Everything except for the message is validated in a test. I think the message does not need to be tested, as others should not use it as a check (they should use the status code). Let me know if you see this differently, and I'll add the check.

fixes #1203 