### PR TITLE
Added security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Security
+
+If you discover a security vulnerability within PocketBase, please send an e-mail to **support at pocketbase.io**.
+
+All reports will be promptly addressed, and you'll be credited accordingly.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Check also the [Testing guide](http://pocketbase.io/docs/testing) to learn how t
 
 If you discover a security vulnerability within PocketBase, please send an e-mail to **support at pocketbase.io**.
 
-All reports will be promptly addressed and you'll be credited accordingly.
+All reports will be promptly addressed, and you'll be credited accordingly.
 
 
 ## Contributing


### PR DESCRIPTION
Hi, this PR adds a security policy, according to: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

It also fixed a missing comma (according to this rule: https://www.grammar-monster.com/lessons/commas_before_conjunctions.htm)

I have choosen to put the `SECURITY.md` in the `.github` dir to not populate the root dir. 
It will still be visible:
> To give people instructions for reporting security vulnerabilities in your project, you can add a SECURITY.md file to your repository's root, docs, or .github folder. When someone creates an issue in your repository, they will see a link to your project's security policy.