### PR TITLE
fixed s3 file upload error caused by underscore in metadata

### DIFF
--- a/tools/filesystem/filesystem.go
+++ b/tools/filesystem/filesystem.go
@@ -142,7 +142,7 @@ func (s *System) UploadFile(file *File, fileKey string) error {
 	opts := &blob.WriterOptions{
 		ContentType: mt.String(),
 		Metadata: map[string]string{
-			"original_filename": originalName,
+			"original-filename": originalName,
 		},
 	}
 
@@ -184,7 +184,7 @@ func (s *System) UploadMultipart(fh *multipart.FileHeader, fileKey string) error
 	opts := &blob.WriterOptions{
 		ContentType: mt.String(),
 		Metadata: map[string]string{
-			"original_filename": originalName,
+			"original-filename": originalName,
 		},
 	}
 

--- a/tools/filesystem/filesystem_test.go
+++ b/tools/filesystem/filesystem_test.go
@@ -177,8 +177,8 @@ func TestFileSystemUploadMultipart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to fetch file attributes: %v", err)
 	}
-	if name, ok := attrs.Metadata["original_filename"]; !ok || name != "test" {
-		t.Fatalf("Expected original_filename to be %q, got %q", "test", name)
+	if name, ok := attrs.Metadata["original-filename"]; !ok || name != "test" {
+		t.Fatalf("Expected original-filename to be %q, got %q", "test", name)
 	}
 }
 


### PR DESCRIPTION
The underscore in the "original_filename" metadata is causing "SignatureDoesNotMatch" error for me when uploading files to s3 storage. Changing the metadata name to "original-filename" resolved the issue.