### PR TITLE
Add filesystem.NewFileFromBytes

### DIFF
--- a/tools/filesystem/file.go
+++ b/tools/filesystem/file.go
@@ -51,7 +51,7 @@ func NewFileFromPath(path string) (*File, error) {
 func NewFileFromBytes(b []byte, name string) (*File, error) {
 	f := &File{}
 
-	f.Reader = &BufReader{b}
+	f.Reader = &bytesReader{b}
 	f.Size = int64(len(b))
 	f.OriginalName = name
 	f.Name = normalizeName(f.Reader, f.OriginalName)
@@ -100,26 +100,26 @@ func (r *PathReader) Open() (io.ReadSeekCloser, error) {
 
 // -------------------------------------------------------------------
 
-var _ FileReader = (*BufReader)(nil)
+var _ FileReader = (*bytesReader)(nil)
 
-type BufReader struct {
+type bytesReader struct {
 	Bytes []byte
 }
 
 // Open implements the [filesystem.FileReader] interface.
-func (r *BufReader) Open() (io.ReadSeekCloser, error) {
-	return NewBytesReadSeekCloser(r.Bytes), nil
+func (r *bytesReader) Open() (io.ReadSeekCloser, error) {
+	return newBytesReadSeekCloser(r.Bytes), nil
 }
 
-type BytesReadSeekCloser struct {
+type bytesReadSeekCloser struct {
 	*bytes.Reader
 }
 
-func NewBytesReadSeekCloser(b []byte) *BytesReadSeekCloser {
-	return &BytesReadSeekCloser{bytes.NewReader(b)}
+func newBytesReadSeekCloser(b []byte) *bytesReadSeekCloser {
+	return &bytesReadSeekCloser{bytes.NewReader(b)}
 }
 
-func (r *BytesReadSeekCloser) Close() error {
+func (r *bytesReadSeekCloser) Close() error {
 	return nil
 }
 

--- a/tools/filesystem/file.go
+++ b/tools/filesystem/file.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -49,10 +50,15 @@ func NewFileFromPath(path string) (*File, error) {
 
 // NewFileFromBytes creates a new File instance from the provided byte slice.
 func NewFileFromBytes(b []byte, name string) (*File, error) {
+	size := len(b)
+	if size == 0 || b == nil {
+		return nil, errors.New("cannot create an empty file")
+	}
+
 	f := &File{}
 
 	f.Reader = &bytesReader{b}
-	f.Size = int64(len(b))
+	f.Size = int64(size)
 	f.OriginalName = name
 	f.Name = normalizeName(f.Reader, f.OriginalName)
 

--- a/tools/filesystem/file.go
+++ b/tools/filesystem/file.go
@@ -114,15 +114,11 @@ type bytesReader struct {
 
 // Open implements the [filesystem.FileReader] interface.
 func (r *bytesReader) Open() (io.ReadSeekCloser, error) {
-	return newBytesReadSeekCloser(r.Bytes), nil
+	return &bytesReadSeekCloser{bytes.NewReader(r.Bytes)}, nil
 }
 
 type bytesReadSeekCloser struct {
 	*bytes.Reader
-}
-
-func newBytesReadSeekCloser(b []byte) *bytesReadSeekCloser {
-	return &bytesReadSeekCloser{bytes.NewReader(b)}
 }
 
 func (r *bytesReadSeekCloser) Close() error {

--- a/tools/filesystem/file.go
+++ b/tools/filesystem/file.go
@@ -51,13 +51,13 @@ func NewFileFromPath(path string) (*File, error) {
 // NewFileFromBytes creates a new File instance from the provided byte slice.
 func NewFileFromBytes(b []byte, name string) (*File, error) {
 	size := len(b)
-	if size == 0 || b == nil {
+	if size == 0 {
 		return nil, errors.New("cannot create an empty file")
 	}
 
 	f := &File{}
 
-	f.Reader = &bytesReader{b}
+	f.Reader = &BytesReader{b}
 	f.Size = int64(size)
 	f.OriginalName = name
 	f.Name = normalizeName(f.Reader, f.OriginalName)
@@ -106,17 +106,18 @@ func (r *PathReader) Open() (io.ReadSeekCloser, error) {
 
 // -------------------------------------------------------------------
 
-var _ FileReader = (*bytesReader)(nil)
+var _ FileReader = (*BytesReader)(nil)
 
-type bytesReader struct {
+type BytesReader struct {
 	Bytes []byte
 }
 
 // Open implements the [filesystem.FileReader] interface.
-func (r *bytesReader) Open() (io.ReadSeekCloser, error) {
+func (r *BytesReader) Open() (io.ReadSeekCloser, error) {
 	return &bytesReadSeekCloser{bytes.NewReader(r.Bytes)}, nil
 }
 
+// bytesReadSeekCloser implements io.ReadSeekCloser
 type bytesReadSeekCloser struct {
 	*bytes.Reader
 }

--- a/tools/filesystem/file_test.go
+++ b/tools/filesystem/file_test.go
@@ -44,9 +44,6 @@ func TestNewFileFromPath(t *testing.T) {
 }
 
 func TestNewFileFromBytes(t *testing.T) {
-	testDir := createTestDir(t)
-	defer os.RemoveAll(testDir)
-
 	// nil bytes
 	if _, err := filesystem.NewFileFromBytes(nil, "photo.jpg"); err == nil {
 		t.Fatal("Expected error, got nil")
@@ -58,12 +55,12 @@ func TestNewFileFromBytes(t *testing.T) {
 	}
 
 	originalName := "notes.txt"
-	f, err := filesystem.NewFileFromBytes([]byte("TODO: Write Tests\n"), originalName)
+	f, err := filesystem.NewFileFromBytes([]byte("text\n"), originalName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if f.Size != 18 {
-		t.Fatalf("Expected Size %v, got %v", 18, f.Size)
+	if f.Size != 5 {
+		t.Fatalf("Expected Size %v, got %v", 5, f.Size)
 	}
 	if f.OriginalName != originalName {
 		t.Fatalf("Expected originalName %q, got %q", originalName, f.OriginalName)

--- a/tools/filesystem/file_test.go
+++ b/tools/filesystem/file_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pocketbase/pocketbase/tools/filesystem"
 )
 
-func TestNewFileFromFromPath(t *testing.T) {
+func TestNewFileFromPath(t *testing.T) {
 	testDir := createTestDir(t)
 	defer os.RemoveAll(testDir)
 
@@ -40,6 +40,33 @@ func TestNewFileFromFromPath(t *testing.T) {
 	}
 	if _, ok := f.Reader.(*filesystem.PathReader); !ok {
 		t.Fatalf("Expected Reader to be PathReader, got %v", f.Reader)
+	}
+}
+
+func TestNewFileFromBytes(t *testing.T) {
+	testDir := createTestDir(t)
+	defer os.RemoveAll(testDir)
+
+	// nil bytes
+	if _, err := filesystem.NewFileFromBytes(nil, "photo.jpg"); err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	// zero bytes
+	if _, err := filesystem.NewFileFromBytes([]byte{}, "photo.jpg"); err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	originalName := "notes.txt"
+	f, err := filesystem.NewFileFromBytes([]byte("TODO: Write Tests\n"), originalName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Size != 18 {
+		t.Fatalf("Expected Size %v, got %v", 18, f.Size)
+	}
+	if f.OriginalName != originalName {
+		t.Fatalf("Expected originalName %q, got %q", originalName, f.OriginalName)
 	}
 }
 

--- a/tools/filesystem/file_test.go
+++ b/tools/filesystem/file_test.go
@@ -54,7 +54,8 @@ func TestNewFileFromBytes(t *testing.T) {
 		t.Fatal("Expected error, got nil")
 	}
 
-	originalName := "notes.txt"
+	originalName := "image_! noext"
+	normalizedNamePattern := regexp.QuoteMeta("image_noext_") + `\w{10}` + regexp.QuoteMeta(".txt")
 	f, err := filesystem.NewFileFromBytes([]byte("text\n"), originalName)
 	if err != nil {
 		t.Fatal(err)
@@ -64,6 +65,9 @@ func TestNewFileFromBytes(t *testing.T) {
 	}
 	if f.OriginalName != originalName {
 		t.Fatalf("Expected originalName %q, got %q", originalName, f.OriginalName)
+	}
+	if match, _ := regexp.Match(normalizedNamePattern, []byte(f.Name)); !match {
+		t.Fatalf("Expected Name to match %v, got %q (%v)", normalizedNamePattern, f.Name, err)
 	}
 }
 


### PR DESCRIPTION
This PR adds tools/filesystem.NewFileFromBytes which should greatly help uploading files from events.  There are a lot of libraries which output bytes.  It's pointless to save it to a file just to read it again.

I was also not able to test this, nor was I able to even compile it.  Baby steps.