### PR TITLE
Check browser cache before process collection resources

### DIFF
--- a/apis/file.go
+++ b/apis/file.go
@@ -29,6 +29,14 @@ func (api *fileApi) download(c echo.Context) error {
 		return NewNotFoundError("", nil)
 	}
 
+	// check browser cache and return 304 if possible
+	ifModifiedSince := c.Request().Header.Get("If-Modified-Since")
+	if ifModifiedSince != "" {
+		c.Response().Header().Set("Last-Modified", ifModifiedSince)
+		c.Response().WriteHeader(304)
+		return nil
+	}
+
 	recordId := c.PathParam("recordId")
 	if recordId == "" {
 		return NewNotFoundError("", nil)


### PR DESCRIPTION
I realize that before api download return data, it has to get collection data -> check thumbnail (via S3 too slow).
I just want to make full use of browser caching.. please give me your opinion 😬 