### PR TITLE
Fixed SQL syntax error in FindCollectionReferences

### DIFF
--- a/daos/collection.go
+++ b/daos/collection.go
@@ -87,7 +87,9 @@ func (dao *Dao) FindCollectionReferences(collection *models.Collection, excludeI
 	query := dao.CollectionQuery()
 	if len(excludeIds) > 0 {
 		uniqueExcludeIds := list.NonzeroUniques(excludeIds)
-		query.AndWhere(dbx.NotIn("id", list.ToInterfaceSlice(uniqueExcludeIds)...))
+		if len(uniqueExcludeIds) > 0 {
+			query.AndWhere(dbx.NotIn("id", list.ToInterfaceSlice(uniqueExcludeIds)...))
+		}
 	}
 	if err := query.All(&collections); err != nil {
 		return nil, err


### PR DESCRIPTION
Minimal reproducible example:
```
package main

import (
	"fmt"
	"os"

	"github.com/pocketbase/dbx"
	"github.com/pocketbase/pocketbase"
	"github.com/pocketbase/pocketbase/core"
	"github.com/pocketbase/pocketbase/tools/list"
)

func main() {
	app := pocketbase.New()

	app.OnAfterBootstrap().Add(func(e *core.BootstrapEvent) error {
		excludeIds := []string{""}
		dao := app.Dao()
		query := dao.CollectionQuery()
		if len(excludeIds) > 0 {
			uniqueExcludeIds := list.NonzeroUniques(excludeIds)
			// if len(uniqueExcludeIds) > 0 {
				query.AndWhere(dbx.NotIn("id", list.ToInterfaceSlice(uniqueExcludeIds)...))
			// }
		}
		fmt.Fprintln(os.Stderr, query.Build().SQL())
		return nil
	})

	app.Start()
}
```
Running this with `go run main.go >/dev/null` generates erroneous SQL:
```
SELECT {{_collections}}.* FROM `_collections` WHERE ()
```
Whereas if we uncomment the if statement generated SQL becomes correct:
```
SELECT {{_collections}}.* FROM `_collections`
```

This minor issue causes cryptic `near ")": syntax error` error if we for example try to delete collection with an empty Id field like this:
```
dao.DeleteCollection(&models.Collection{})
```