### PR TITLE
Allows files to be read through FileSystem interface.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.19.4'
+          go-version: '>=1.19.5'
 
       # This step usually is not needed because the /ui/dist is pregenerated locally
       # but its here to ensure that each release embeds the latest admin ui artifacts.

--- a/tools/filesystem/filesystem.go
+++ b/tools/filesystem/filesystem.go
@@ -285,6 +285,16 @@ var manualExtensionContentTypes = map[string]string{
 	".css": "text/css",      // (see https://github.com/gabriel-vasile/mimetype/pull/113)
 }
 
+// / GetFile returns a file content reader for given file key
+// / NB! Make sure to call `Close()` after you are done working with it.
+func (s *System) GetFile(fileKey string) (io.ReadCloser, error) {
+	br, readErr := s.bucket.NewReader(s.ctx, fileKey, nil)
+	if readErr != nil {
+		return nil, readErr
+	}
+	return br, nil
+}
+
 // Serve serves the file at fileKey location to an HTTP response.
 func (s *System) Serve(res http.ResponseWriter, req *http.Request, fileKey string, name string) error {
 	br, readErr := s.bucket.NewReader(s.ctx, fileKey, nil)

--- a/tools/filesystem/filesystem_test.go
+++ b/tools/filesystem/filesystem_test.go
@@ -348,7 +348,25 @@ func TestFileSystemServe(t *testing.T) {
 		}
 	}
 }
+func TestFileSystemGetFile(t *testing.T) {
+	dir := createTestDir(t)
+	defer os.RemoveAll(dir)
 
+	fs, err := filesystem.NewLocal(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fs.Close()
+
+	f, fErr := fs.GetFile("image.png")
+	if fErr != nil {
+		t.Fatal(fErr)
+	}
+	defer f.Close()
+	if f == nil {
+		t.Fatal("File is supposed to be found")
+	}
+}
 func TestFileSystemServeSingleRange(t *testing.T) {
 	dir := createTestDir(t)
 	defer os.RemoveAll(dir)


### PR DESCRIPTION
The functionality is needed while Pocketbase is used in embedded mode. 
Currently, there is no way to read file content while Pocketbase is embedded (except Downloading over HTTP or mocking up http request via httptest package). 
The PR exposes file reader via public method. The client (calling method) is responsible for closing the reader. 