### PR TITLE
Prevent autoclosing multiselect choicebox

### DIFF
--- a/ui/src/components/base/Select.svelte
+++ b/ui/src/components/base/Select.svelte
@@ -264,7 +264,7 @@
                 {#each filteredItems as item}
                     <div
                         tabindex="0"
-                        class="dropdown-item option closable"
+                        class="dropdown-item option {multiple ? '':'closable'}"
                         class:selected={isSelected(item)}
                         on:click={(e) => handleOptionSelect(e, item)}
                         on:keydown={(e) => handleOptionKeypress(e, item)}


### PR DESCRIPTION
Allow to select multiple elements in a multi select box, without the select box closing upon each selection.

The proposed change will only add the _closable_ class to dropdown items, if the select is a single select (multiple === false). This prevents the _Toggler_ instance from closing the dropdown, since _handleClickToggle_ checks if the element has the _closable_ class before closing the dropdown.