### PR TITLE
Add Lua-based cloud code functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/pocketbase/dbx v1.9.0
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.6.1
+	github.com/yuin/gopher-lua v1.1.0
 	gocloud.dev v0.28.0
 	golang.org/x/crypto v0.5.0
 	golang.org/x/net v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,6 @@ github.com/aws/aws-sdk-go v1.43.11/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4
 github.com/aws/aws-sdk-go v1.43.31/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.128/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.151/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/aws-sdk-go v1.44.178 h1:4igreoWPEA7xVLnOeSXLhDXTsTSPKQONZcQ3llWAJw0=
-github.com/aws/aws-sdk-go v1.44.178/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go v1.44.187 h1:D5CsRomPnlwDHJCanL2mtaLIcbhjiWxNh5j8zvaWdJA=
 github.com/aws/aws-sdk-go v1.44.187/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
@@ -529,21 +527,15 @@ github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.9/go.mod h1:vCmV1q1VK
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10 h1:dK82zF6kkPeCo8J1e+tGx4JdvDIQzj7ygIoLg8WMuGs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.10/go.mod h1:VeTZetY5KRJLuD/7fkQXMU6Mw7H5m/KP2J5Iy9osMno=
 github.com/aws/aws-sdk-go-v2/config v1.18.3/go.mod h1:BYdrbeCse3ZnOD5+2/VE/nATOK8fEUpBtmPMdKSyhMU=
-github.com/aws/aws-sdk-go-v2/config v1.18.8 h1:lDpy0WM8AHsywOnVrOHaSMfpaiV2igOw8D7svkFkXVA=
-github.com/aws/aws-sdk-go-v2/config v1.18.8/go.mod h1:5XCmmyutmzzgkpk/6NYTjeWb6lgo9N170m1j6pQkIBs=
 github.com/aws/aws-sdk-go-v2/config v1.18.10 h1:Znce11DWswdh+5kOsIp+QaNfY9igp1QUN+fZHCKmeCI=
 github.com/aws/aws-sdk-go-v2/config v1.18.10/go.mod h1:VATKco+pl+Qe1WW+RzvZTlPPe/09Gg9+vM0ZXsqb16k=
 github.com/aws/aws-sdk-go-v2/credentials v1.13.3/go.mod h1:/rOMmqYBcFfNbRPU0iN9IgGqD5+V2yp3iWNmIlz0wI4=
-github.com/aws/aws-sdk-go-v2/credentials v1.13.8 h1:vTrwTvv5qAwjWIGhZDSBH/oQHuIQjGmD232k01FUh6A=
-github.com/aws/aws-sdk-go-v2/credentials v1.13.8/go.mod h1:lVa4OHbvgjVot4gmh1uouF1ubgexSCN92P6CJQpT0t8=
 github.com/aws/aws-sdk-go-v2/credentials v1.13.10 h1:T4Y39IhelTLg1f3xiKJssThnFxsndS8B6OnmcXtKK+8=
 github.com/aws/aws-sdk-go-v2/credentials v1.13.10/go.mod h1:tqAm4JmQaShel+Qi38hmd1QglSnnxaYt50k/9yGQzzc=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.19/go.mod h1:VihW95zQpeKQWVPGkwT+2+WJNQV8UXFfMTWdU6VErL8=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21 h1:j9wi1kQ8b+e0FBVHxCqCGo4kxDU175hoDHcWAi0sauU=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.21/go.mod h1:ugwW57Z5Z48bpvUyZuaPy4Kv+vEfJWnIrky7RmkBvJg=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.42/go.mod h1:LHOsygMiW/14CkFxdXxvzKyMh3jbk/QfZVaDtCbLkl8=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.47 h1:E884ndKWVGt8IhtUuGhXbEsmaCvdAAkTTUDu7uAok1g=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.47/go.mod h1:KybsEsmXLO0u75FyS3F0sY4OQ97syDe8z+ISq8oEczA=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.49 h1:zPFhadkmXbXu3RVXTPU4HVW+g2DStMY+01cJaj//+Cw=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.49/go.mod h1:N9gSChQkKpdAj7vRpfKma4ND88zoZM+v6W2lJgWrDh4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25/go.mod h1:Zb29PYkf42vVYQY6pvSyJCJcFHlPIiY+YKdPtwnvMkY=
@@ -572,8 +564,6 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.21 h1:vY5siRXvW5TrO
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.21/go.mod h1:WZvNXT1XuH8dnJM0HvOlvk+RNn7NbAPvA/ACO0QarSc=
 github.com/aws/aws-sdk-go-v2/service/kms v1.19.0/go.mod h1:kZodDPTQjSH/qM6/OvyTfM5mms5JHB/EKYp5dhn/vI4=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.29.4/go.mod h1:/NHbqPRiwxSPVOB2Xr+StDEH+GWV/64WwnUjv4KYzV0=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.30.0 h1:wddsyuESfviaiXk3w9N6/4iRwTg/a3gktjODY6jYQBo=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.30.0/go.mod h1:L2l2/q76teehcW7YEsgsDjqdsDTERJeX3nOMIFlgGUE=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.1 h1:kIgvVY7PHx4gIb0na/Q9gTWJWauTwhKdaqJjX8PkIY8=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.30.1/go.mod h1:L2l2/q76teehcW7YEsgsDjqdsDTERJeX3nOMIFlgGUE=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.16.8/go.mod h1:k6CPuxyzO247nYEM1baEwHH1kRtosRCvgahAepaaShw=
@@ -587,8 +577,6 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.8/go.mod h1:er2JHN+kBY6FcMfcB
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0 h1:Jfly6mRxk2ZOSlbCvZfKNS7TukSx1mIzhSsqZ/IGSZI=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.0/go.mod h1:TZSH7xLO7+phDtViY/KUp9WGCJMQkLJ/VpgkTFd5gh8=
 github.com/aws/aws-sdk-go-v2/service/sts v1.17.5/go.mod h1:bXcN3koeVYiJcdDU89n3kCYILob7Y34AeLopUbZgLT4=
-github.com/aws/aws-sdk-go-v2/service/sts v1.18.0 h1:kOO++CYo50RcTFISESluhWEi5Prhg+gaSs4whWabiZU=
-github.com/aws/aws-sdk-go-v2/service/sts v1.18.0/go.mod h1:+lGbb3+1ugwKrNTWcf2RT05Xmp543B06zDFTwiTLp7I=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.2 h1:J/4wIaGInCEYCGhTSruxCxeoA5cy91a+JT7cHFKFSHQ=
 github.com/aws/aws-sdk-go-v2/service/sts v1.18.2/go.mod h1:+lGbb3+1ugwKrNTWcf2RT05Xmp543B06zDFTwiTLp7I=
 github.com/aws/smithy-go v1.13.4/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
@@ -840,7 +828,6 @@ github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d/go.mod h1:DngW8
 github.com/dop251/goja_nodejs v0.0.0-20221009164102-3aa5028e57f6 h1:p3QZwRRfCN7Qr3GNBTMKBkLFjEm3DHR4MaJABvsiqgk=
 github.com/dop251/goja_nodejs v0.0.0-20221009164102-3aa5028e57f6/go.mod h1:+CJy9V5cGycP5qwp6RM5jLg+TFEMyGtD7A9xUbU/BOQ=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
@@ -874,7 +861,6 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
-github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
@@ -1024,7 +1010,6 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
 github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
@@ -1587,8 +1572,6 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pocketbase/dbx v1.8.0 h1:kjf3mgmmE12t8IG48kJOeIyBmRi0A1sl6Hsezv4PoiA=
-github.com/pocketbase/dbx v1.8.0/go.mod h1:xXRCIAKTHMgUCyCKZm55pUOdvFziJjQfXaWKhu2vhMs=
 github.com/pocketbase/dbx v1.9.0 h1:HYY0hQcbopfJFFqJqcjt39lg6VTKlIRoDbUFY6ZC4iM=
 github.com/pocketbase/dbx v1.9.0/go.mod h1:xXRCIAKTHMgUCyCKZm55pUOdvFziJjQfXaWKhu2vhMs=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -1657,8 +1640,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rakyll/embedmd v0.0.0-20171029212350-c8060a0752a2/go.mod h1:7jOTMgqac46PZcF54q6l2hkLEG8op93fZu61KmxWDV4=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa h1:tEkEyxYeZ43TR55QU/hsIt9aRGBxbgGuz9CGykjvogY=
-github.com/remyoudompheng/bigfft v0.0.0-20220927061507-ef77025ab5aa/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20230126093431-47fa9a501578 h1:VstopitMQi3hZP0fzvnsLmzXZdQGc4bEcgu24cp+d4M=
 github.com/remyoudompheng/bigfft v0.0.0-20230126093431-47fa9a501578/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -1808,6 +1789,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE=
+github.com/yuin/gopher-lua v1.1.0/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -2476,8 +2459,6 @@ google.golang.org/api v0.99.0/go.mod h1:1YOf74vkVndF7pG6hIHuINsM7eWwpVTAfNMNiL91
 google.golang.org/api v0.100.0/go.mod h1:ZE3Z2+ZOr87Rx7dqFsdRQkRBk36kDtp/h+QpHbB7a70=
 google.golang.org/api v0.102.0/go.mod h1:3VFl6/fzoA+qNuS1N1/VfXY4LjoXN/wzeIp7TweWwGo=
 google.golang.org/api v0.103.0/go.mod h1:hGtW6nK1AC+d9si/UBhw8Xli+QMOf6xyNAyJw4qU9w0=
-google.golang.org/api v0.107.0 h1:I2SlFjD8ZWabaIFOfeEDg3pf0BHJDh6iYQ1ic3Yu/UU=
-google.golang.org/api v0.107.0/go.mod h1:2Ts0XTHNVWxypznxWOYUeI4g3WdP9Pk2Qk58+a/O9MY=
 google.golang.org/api v0.108.0 h1:WVBc/faN0DkKtR43Q/7+tPny9ZoLZdIiAyG5Q9vFClg=
 google.golang.org/api v0.108.0/go.mod h1:2Ts0XTHNVWxypznxWOYUeI4g3WdP9Pk2Qk58+a/O9MY=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -2613,8 +2594,6 @@ google.golang.org/genproto v0.0.0-20221109142239-94d6d90a7d66/go.mod h1:rZS5c/ZV
 google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221201204527-e3fa12d562f3/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f h1:BWUVssLB0HVOSY78gIdvk1dTVYtT1y8SBWtPYuTJ/6w=
-google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/genproto v0.0.0-20230125152338-dcaf20b6aeaa h1:qQPhfbPO23fwm/9lQr91L1u62Zo6cm+zI+slZT+uf+o=
 google.golang.org/genproto v0.0.0-20230125152338-dcaf20b6aeaa/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
@@ -2662,8 +2641,6 @@ google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCD
 google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
-google.golang.org/grpc v1.52.0 h1:kd48UiU7EHsV4rnLyOJRuP/Il/UHE7gdDAQ+SZI7nZk=
-google.golang.org/grpc v1.52.0/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
 google.golang.org/grpc v1.52.3 h1:pf7sOysg4LdgBqduXveGKrcEwbStiK2rtfghdzlUYDQ=
 google.golang.org/grpc v1.52.3/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
@@ -2811,8 +2788,6 @@ modernc.org/memory v1.5.0 h1:N+/8c5rE6EqugZwHii4IFsaJ7MUhoWX07J5tC/iI5Ds=
 modernc.org/memory v1.5.0/go.mod h1:PkUhL0Mugw21sHPeskwZW4D6VscE/GQJOnIpCnW6pSU=
 modernc.org/opt v0.1.3 h1:3XOZf2yznlhC+ibLltsDGzABUGVx8J6pnFMS3E4dcq4=
 modernc.org/opt v0.1.3/go.mod h1:WdSiB5evDcignE70guQKxYUl14mgWtbClRi5wmkkTX0=
-modernc.org/sqlite v1.20.2 h1:9AaVzJH1Yf0u9iOZRjjuvqxLoGqybqVFbAUC5rvi9u8=
-modernc.org/sqlite v1.20.2/go.mod h1:zKcGyrICaxNTMEHSr1HQ2GUraP0j+845GYw37+EyT6A=
 modernc.org/sqlite v1.20.3 h1:SqGJMMxjj1PHusLxdYxeQSodg7Jxn9WWkaAQjKrntZs=
 modernc.org/sqlite v1.20.3/go.mod h1:zKcGyrICaxNTMEHSr1HQ2GUraP0j+845GYw37+EyT6A=
 modernc.org/strutil v1.1.3 h1:fNMm+oJklMGYfU9Ylcywl0CO5O6nTfaowNsh2wpPjzY=

--- a/plugins/cloudcode/api/api.go
+++ b/plugins/cloudcode/api/api.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	lua "github.com/yuin/gopher-lua"
+)
+
+// _app is a reference to the core.App that was used to initialize the cloud code system.
+// This is used by some modules (via getApp()) to interact with the main pocketbase application.
+var _app *core.App = nil
+
+func getApp() core.App {
+	return *_app
+}
+
+func Bind(a *core.App, l *lua.LState) {
+	_app = a
+
+	root := l.NewTable()
+	//l.RawSet(root, lua.LString("db"), getDbModule(l))
+	l.RawSet(root, lua.LString("events"), getEventsModule(l))
+	l.RawSet(root, lua.LString("meta"), getMetaModule(l))
+	l.RawSet(root, lua.LString("mail"), getMailModule(l))
+
+	l.SetGlobal("pb", root)
+}

--- a/plugins/cloudcode/api/db.go
+++ b/plugins/cloudcode/api/db.go
@@ -1,0 +1,6 @@
+package api
+
+//func getDbModule(l *lua.LState) *lua.LTable {
+//	m := l.NewTable()
+//	return m
+//}

--- a/plugins/cloudcode/api/events.go
+++ b/plugins/cloudcode/api/events.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	lua "github.com/yuin/gopher-lua"
+	"reflect"
+)
+
+func getEventsModule(l *lua.LState) *lua.LTable {
+	m := l.SetFuncs(l.NewTable(), buildEventsExports())
+	return m
+}
+
+// this function was a PITA to write. somebody smarter than me may want to refactor it a bit.
+func buildEventsExports() map[string]lua.LGFunction {
+	exports := make(map[string]lua.LGFunction)
+
+	app := reflect.TypeOf(getApp())
+	reflectedApp := reflect.ValueOf(getApp())
+
+	// Export each On* method for Lua code. In Lua, the method name is lower camel cased.
+	for i := 0; i < app.NumMethod(); i++ {
+		method := app.Method(i)
+		if method.Name[0:2] == "On" {
+			hook := reflectedApp.MethodByName(method.Name).Call([]reflect.Value{})
+			m := hook[0].MethodByName("Add")
+
+			handlerType := m.Type().In(0)
+
+			exports["o"+method.Name[1:]] = func(l *lua.LState) int {
+				f := l.ToFunction(1)
+
+				handler := reflect.MakeFunc(handlerType, func(args []reflect.Value) []reflect.Value {
+					// TODO: pass event object to lua call somehow.
+					err := l.CallByParam(lua.P{
+						Fn:      f,
+						NRet:    0,
+						Protect: true,
+					})
+
+					return []reflect.Value{reflect.ValueOf(&err).Elem()}
+				})
+
+				m.Call([]reflect.Value{handler})
+
+				return 0
+			}
+		}
+	}
+
+	return exports
+}

--- a/plugins/cloudcode/api/mail.go
+++ b/plugins/cloudcode/api/mail.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"github.com/pocketbase/pocketbase/tools/mailer"
+	lua "github.com/yuin/gopher-lua"
+	"net/mail"
+)
+
+func getMailModule(l *lua.LState) *lua.LTable {
+	m := l.SetFuncs(l.NewTable(), mailExports)
+	return m
+}
+
+var mailExports = map[string]lua.LGFunction{
+	"send": sendMessage,
+}
+
+func sendMessage(l *lua.LState) int {
+	// TODO: fully implement after https://github.com/pocketbase/pocketbase/issues/1727 is done.
+
+	message := &mailer.Message{
+		From: mail.Address{
+			Address: getApp().Settings().Meta.SenderAddress,
+			Name:    getApp().Settings().Meta.SenderName,
+		},
+		To:      mail.Address{Address: "test@example.com", Name: "Test Recipient"},
+		Subject: "Test Subject",
+		Text:    "This is the text of the message",
+		HTML:    "<html><body><p><strong>This</strong> is the HTML text of the message</p></body></html>",
+	}
+
+	getApp().NewMailClient().Send(message)
+
+	return 0
+}

--- a/plugins/cloudcode/api/meta.go
+++ b/plugins/cloudcode/api/meta.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"github.com/pocketbase/pocketbase"
+	lua "github.com/yuin/gopher-lua"
+)
+
+func getMetaModule(l *lua.LState) *lua.LTable {
+	m := l.NewTable()
+	l.RawSet(m, lua.LString("version"), lua.LString(pocketbase.Version))
+	return m
+}

--- a/plugins/cloudcode/cloudcode.go
+++ b/plugins/cloudcode/cloudcode.go
@@ -1,0 +1,59 @@
+package cloudcode
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/plugins/cloudcode/api"
+	lua "github.com/yuin/gopher-lua"
+	"log"
+	"os"
+)
+
+// MustRegister initializes a Lua environment and panics if anything goes wrong.
+// See Register for param information.
+func MustRegister(app core.App, cloudCode string, cloudCodeInit string) {
+	if err := Register(app, cloudCode, cloudCodeInit); err != nil {
+		panic(err)
+	}
+}
+
+// Register initializes a Lua environment for the application.
+// `cloudCode` is the main cloud code file. `cloudCodeInit` (if provided) is run before
+// the main cloud code and can be used for things like sandboxing or preloading libraries.
+func Register(app core.App, cloudCode string, cloudCodeInit string) error {
+	// If the cloud code file isn't available, there's nothing we can do.
+	if _, err := os.Stat(cloudCode); os.IsNotExist(err) {
+		// TODO: Is there a better way to handle log output?
+		log.Println("could not find cloud code")
+		return nil
+	}
+
+	// If an init script was provided and is inaccessible, exiting early is better (in case the user is relying on the
+	// init script for sandboxing or other security measures.
+	if cloudCodeInit != "" {
+		if _, err := os.Stat(cloudCodeInit); os.IsNotExist(err) {
+			// TODO: Is there a better way to handle log output?
+			log.Println("could not find cloud code init script")
+			return nil
+		}
+	}
+
+	// Create a new Lua environment and bind all Pocketbase APIs.
+	L := lua.NewState()
+	api.Bind(&app, L)
+
+	// If we have an init file, run it now.
+	if cloudCodeInit != "" {
+		err := L.DoFile(cloudCodeInit)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Finally, run the user-provided cloud code.
+	err := L.DoFile(cloudCode)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
I've been working on building a cloud code system in the style of Parse Server for Pocketbase.

Here's what I have so far:

* A way to load some Lua scripts given the path to the main script (`--cloudCode /path/to/main.lua`)
* A way to run some Lua just prior to the main script to help with sandboxing or pre-loading modules or whatever (in the event that somebody is e.g. running untrusted cloud code or wants to limit the functionality exposed to developers)
* A Pocketbase API that is exposed to cloud code through the `pb` global, including a handful of modules which are accessible as children of the `pb` global:
    * `pb.meta`: Not sure this should continue to exist, but it was a simple starting point. The only thing available here is `pb.meta.version`, which is just `pocketbase.Version`.
    * `pb.events`: I imagined this as a way to register events without the `app.On*` function calls in Go. Right now, this module reflects all of the `On*` methods out of `core.BaseApp` and exposes the equivalent Lua functions (examples below)
    * `pb.mail`: Since it is not currently possible to send mail messages without writing Go, this is pretty useful. Right now, `pb.mail.send()` just sends a hardcoded message. I'll build out this module further after #1727 is wrapped.
    * `pb.db`: This is just a placeholder for now. My intent is to mirror as much of `app.Dao` as is feasible.

Some of the things still on my list:

* `pb.events`: some events really need the event object passed to the handler function. Right now, I'm not passing it along at all, as I was more interested in getting the reflection stuff working properly + being able to bind Lua functions to Pocketbase hooks.
* `pb.events`: it might make more sense for this to be called `pb.hooks` instead.
* Build some way of auto-generating a `pb.def.lua` file sort of like the files in https://github.com/CppCXY/emmylua-openresty-api so that Emmylua (the Lua language server) will be able to provide cloud code autocompletion and such.
* Provide some way of testing cloud code
* Write Go tests as needed
* Write an example sandboxing script for users running untrusted cloud code. https://stackoverflow.com/questions/1224708/how-can-i-create-a-secure-lua-sandbox and http://lua-users.org/wiki/SandBoxes are both things that I've been looking at.
* Documentation 
* Some kind of work queue functionality. I noticed there was a TODO elsewhere in the pocketbase code to add something like this. I think it would be extremely helpful to have something like this to rely on for e.g. sending lots of email messages. It'd be a lot quicker to queue them up and process them in the background, rather than send them synchronously.
* Build a roadmap for any other modules that should be implemented. There are many gopher-lua extensions available that might be of interest: https://github.com/yuin/gopher-lua#libraries-for-gopherlua
* Registering new routes. I had two different registration methods in mind -- one for static routes, and one for dynamic routes. Static routes essentially just point at a directory of files that are served directly (without processing Lua code on each request). Dynamic routes would invoke the Lua callback for each request.
* Cloud functions/jobs. I thought it was kind of a strange concept when I first started using Parse Server, but I definitely had a couple of uses for them. Relevant Parse Server docs for [functions](https://docs.parseplatform.org/cloudcode/guide/#cloud-functions) and [jobs](https://docs.parseplatform.org/cloudcode/guide/#cloud-jobs).
* Maybe some way to read/write config values? This could be useful for version controlled configuration deployed as part of a CI workflow.
* Migrations and/or [defined schema](https://docs.parseplatform.org/defined-schema/guide/) functionality. I saw that the `jsvm` plugin had migration functionality. At the very least, it might be helpful to re-implement that in Lua. I'd also be very interested in a defined schema mechanism that essentially does the same stuff as the Export/Import schema functionality in the admin UI, but by using a JSON file on disk instead.
* Some kind of audit-trail functionality in the admin UI. Many CMSes have similar functionality ("so and so edited record asdjfsjjdsfkdsj" or "adminuser configured google authentication" or whatever). It would be possible to wire up a `pb.log` module that can write to this log as well.

Here are a couple of super simple cloud code scripts that I've been using during testing:

(you can drop each of these into some random lua file and run them on pocketbase startup with the `-cloudCode` flag)

```lua
--- you can use any of the app.On* functions here -- it's just a lowercase o instead.
pb.events.onAfterBootstrap(function()
    --- this shows up in the pocketbase log output
    print("on after bootstrap")

    --- I tried this after configuring mailhog locally and it ran pretty quick.
    local i = 0
    repeat
        print("sending message:", i)
        pb.mail.send()
        i = i + 1
    until( i == 100 )
end)
```

```lua
pb.events.onBeforeBootstrap(function()
    print(pb.meta.version)
end)
```

I'll update this PR as I continue (or you can close it if you'd prefer that I open a different PR down the road a bit).

Also: I did see the `jsvm` plugin, but I wasn't too excited about extending that: I just really dislike writing Javascript in general. I find Lua to be a very pleasant language + it's a low barrier to entry for people who are using Pocketbase for non-web things (e.g. Flutter applications).

My first attempt at this was using Tengo, but the language tooling really isn't there (e.g. there's no syntax highlighting in Jetbrains IDEs). If you're curious, that branch is here: https://github.com/cweagans/pocketbase/tree/cloudcode -- I'm not planning on continuing with that though.