### PR TITLE
added a new line in line 10

### DIFF
--- a/ui/embed.go
+++ b/ui/embed.go
@@ -7,7 +7,7 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
-//go:embed all:dist
+// go:embed all:dist
 var distDir embed.FS
 
 // DistDirFS contains the embedded dist directory files (without the "dist" prefix)


### PR DESCRIPTION
from this //go:embed all:dist to // go:embed all:dist caused this error when installing or running a file
$GOPATH/pkg/mod/github.com/pocketbase/pocketbase@v0.12.3/ui/embed.go:10:12: pattern all:dist: no matching files found