### PR TITLE
Sqlite CLI Query Command

### DIFF
--- a/cmd/sqlite.go
+++ b/cmd/sqlite.go
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewServeCommand creates and returns new command responsible for
-// starting the default PocketBase web server.
+// NewSQLiteCommand allows the user to run arbitrary SQL commands on the database from the CLI
+//Example: pocketbase.exe sqlite "DELETE FROM users WHERE name = 'foo'"
 func NewSQLiteCommand(app core.App) *cobra.Command {
 
 	command := &cobra.Command{

--- a/cmd/sqlite.go
+++ b/cmd/sqlite.go
@@ -9,7 +9,6 @@ import (
 // NewSQLiteCommand allows the user to run arbitrary SQL commands on the database from the CLI
 //Example: pocketbase.exe sqlite "DELETE FROM users WHERE name = 'foo'"
 func NewSQLiteCommand(app core.App) *cobra.Command {
-
 	command := &cobra.Command{
 		Use:   "sqlite",
 		Short: "Run arbitrary SQL commands on the database",
@@ -32,7 +31,7 @@ func NewSQLiteCommand(app core.App) *cobra.Command {
 				color.Yellow("Error: %v", err)
 				return
 			}
-			color.Green("Sucess! Affected %v row(s)", rowsAffected)
+			color.Green("Success! Affected %v row(s)", rowsAffected)
 		},
 	}
 

--- a/cmd/sqlite.go
+++ b/cmd/sqlite.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"github.com/fatih/color"
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/spf13/cobra"
+)
+
+// NewServeCommand creates and returns new command responsible for
+// starting the default PocketBase web server.
+func NewSQLiteCommand(app core.App) *cobra.Command {
+
+	command := &cobra.Command{
+		Use:   "sqlite",
+		Short: "Run arbitrary SQL commands on the database",
+		Run: func(command *cobra.Command, args []string) {
+			//Checks to make sure a query was provided
+			if len(args) == 0 {
+				color.Red("Error: No query provided")
+				return
+			}
+			//Runs the SQLite command
+			query := args[0]
+			result, err := app.Dao().DB().NewQuery(query).Execute()
+			if err != nil {
+				color.Red("Error: %v", err)
+				return
+			}
+			//Outputs how many rows were affected
+			rowsAffected, err := result.RowsAffected()
+			if err != nil {
+				color.Yellow("Error: %v", err)
+				return
+			}
+			color.Green("Sucess! Affected %v row(s)", rowsAffected)
+		},
+	}
+
+	return command
+}

--- a/pocketbase.go
+++ b/pocketbase.go
@@ -138,7 +138,8 @@ func (pb *PocketBase) Start() error {
 	// register system commands
 	pb.RootCmd.AddCommand(cmd.NewServeCommand(pb, !pb.hideStartBanner))
 	pb.RootCmd.AddCommand(cmd.NewTempUpgradeCommand(pb))
-
+	pb.RootCmd.AddCommand(cmd.NewSQLiteCommand(pb))
+	
 	return pb.Execute()
 }
 


### PR DESCRIPTION
Added a new CLI command called "sqlite". It allows you to run SQLite queries on the database from the CLI.

Example: pocketbase.exe sqlite "DELETE FROM users WHERE name = 'foo'"

I saw issue [2236](https://github.com/pocketbase/pocketbase/issues/2236) and figured it would be easy to implement. First time contributing to open-source code. I ran the linter and there are no errors with my code.