### PR TITLE
CLI option to expand autocert host whitelist

### DIFF
--- a/apis/serve.go
+++ b/apis/serve.go
@@ -26,7 +26,7 @@ type ServeOptions struct {
 	ShowStartBanner bool
 	HttpAddr        string
 	HttpsAddr       string
-	TlsDomain       string
+	TlsDomains      string
 	AllowedOrigins  []string // optional list of CORS origins (default to "*")
 	BeforeServeFunc func(server *http.Server) error
 }
@@ -76,9 +76,14 @@ func Serve(app core.App, options *ServeOptions) error {
 
 	mainHost, _, _ := net.SplitHostPort(mainAddr)
 
-	hostWhitelist := []string{mainHost, "www." + mainHost}
-	if options.TlsDomain != "" {
-		hostWhitelist = append(hostWhitelist, options.TlsDomain)
+	hostWhitelist := []string{mainHost}
+	if options.TlsDomains != "" {
+		tlsDomainsSplit := strings.Split(options.TlsDomains, ",")
+		hostWhitelist = append(hostWhitelist, tlsDomainsSplit...)
+	}
+
+	for _, host := range hostWhitelist {
+		hostWhitelist = append(hostWhitelist, "www."+host)
 	}
 
 	certManager := autocert.Manager{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -15,6 +15,7 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 	var allowedOrigins []string
 	var httpAddr string
 	var httpsAddr string
+	var tlsDomain string
 
 	command := &cobra.Command{
 		Use:   "serve",
@@ -23,6 +24,7 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 			err := apis.Serve(app, &apis.ServeOptions{
 				HttpAddr:        httpAddr,
 				HttpsAddr:       httpsAddr,
+				TlsDomain:       tlsDomain,
 				ShowStartBanner: showStartBanner,
 				AllowedOrigins:  allowedOrigins,
 			})
@@ -52,6 +54,13 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 		"https",
 		"",
 		"api HTTPS server address (auto TLS via Let's Encrypt)\nthe incoming --http address traffic also will be redirected to this address",
+	)
+
+	command.PersistentFlags().StringVar(
+		&tlsDomain,
+		"tls-domain",
+		"",
+		"domain name for TLS certificate (auto TLS via Let's Encrypt)",
 	)
 
 	return command

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -15,7 +15,7 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 	var allowedOrigins []string
 	var httpAddr string
 	var httpsAddr string
-	var tlsDomain string
+	var tlsDomains string
 
 	command := &cobra.Command{
 		Use:   "serve",
@@ -24,7 +24,7 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 			err := apis.Serve(app, &apis.ServeOptions{
 				HttpAddr:        httpAddr,
 				HttpsAddr:       httpsAddr,
-				TlsDomain:       tlsDomain,
+				TlsDomains:      tlsDomains,
 				ShowStartBanner: showStartBanner,
 				AllowedOrigins:  allowedOrigins,
 			})
@@ -57,10 +57,10 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 	)
 
 	command.PersistentFlags().StringVar(
-		&tlsDomain,
-		"tlsDomain",
+		&tlsDomains,
+		"tlsDomains",
 		"",
-		"domain name for TLS certificate (auto TLS via Let's Encrypt)",
+		"comma separated fully qualified domain names\n(facilitates Let's Encrypt domain verification when behind NAT)",
 	)
 
 	return command

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -58,7 +58,7 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 
 	command.PersistentFlags().StringVar(
 		&tlsDomain,
-		"tls-domain",
+		"tlsDomain",
 		"",
 		"domain name for TLS certificate (auto TLS via Let's Encrypt)",
 	)


### PR DESCRIPTION
Let's Encrypt cert enrollment has issues when behind NAT.
The service can't bind to the public domain's IP when the host doesn't own it, crashing the process on startup.
When changing --https to bind to a private IP, autocert would trip over the fact that the public domain isn't in the host whitelist.

This should provide a simple method to avoid the bind error, and add any other domains autocert could need to verify.

