### PR TITLE
Fix URL in when in base path exists

### DIFF
--- a/ui/src/components/collections/CollectionAuthOptionsTab.svelte
+++ b/ui/src/components/collections/CollectionAuthOptionsTab.svelte
@@ -181,7 +181,7 @@
         {#if collection.options.allowOAuth2Auth}
             <div class="block" transition:slide|local={{ duration: 150 }}>
                 <div class="flex p-t-base">
-                    <a href="/_/#/settings/auth-providers" target="_blank" class="btn btn-sm btn-outline">
+                    <a href="#/settings/auth-providers" target="_blank" class="btn btn-sm btn-outline">
                         <span class="txt">Manage OAuth2 providers</span>
                     </a>
                 </div>


### PR DESCRIPTION
Broken when we are in base path situation.
e.g.
Pocket installation is https://api.xxx.com/v2 then when go to oauth provider settings page will be broken