### PR TITLE
fix: confusing minor typo in deprecated RequestData(c)

### DIFF
--- a/apis/record_helpers.go
+++ b/apis/record_helpers.go
@@ -21,7 +21,7 @@ const ContextRequestInfoKey = "requestInfo"
 
 // Deprecated: Use RequestInfo instead.
 func RequestData(c echo.Context) *models.RequestInfo {
-	log.Println("RequestInfo(c) is depracated and will be removed in the future! You can replace it with RequestInfo(c).")
+	log.Println("RequestData(c) is deprecated and will be removed in the future! You can replace it with RequestInfo(c).")
 	return RequestInfo(c)
 }
 


### PR DESCRIPTION
Got this confusing error 
`RequestInfo(c) is depracated and will be removed in the future! You can replace it with RequestInfo(c).`
turns out it's a typo in the deprecated RequestData method