### PR TITLE
Feature/add settings information to NewWithConfig

### DIFF
--- a/core/base.go
+++ b/core/base.go
@@ -170,10 +170,11 @@ type BaseAppConfig struct {
 	DataDir          string
 	EncryptionEnv    string
 	IsDebug          bool
-	DataMaxOpenConns int // default to 500
-	DataMaxIdleConns int // default 20
-	LogsMaxOpenConns int // default to 100
-	LogsMaxIdleConns int // default to 5
+	DataMaxOpenConns int                // default to 500
+	DataMaxIdleConns int                // default 20
+	LogsMaxOpenConns int                // default to 100
+	LogsMaxIdleConns int                // default to 5
+	ServiceSettings  *settings.Settings // default settings.New()
 }
 
 // NewBaseApp creates and returns a new BaseApp instance
@@ -190,7 +191,7 @@ func NewBaseApp(config BaseAppConfig) *BaseApp {
 		logsMaxOpenConns:    config.LogsMaxOpenConns,
 		logsMaxIdleConns:    config.LogsMaxIdleConns,
 		cache:               store.New[any](nil),
-		settings:            settings.New(),
+		settings:            config.ServiceSettings,
 		subscriptionsBroker: subscriptions.NewBroker(),
 
 		// app event hooks

--- a/core/base_test.go
+++ b/core/base_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pocketbase/pocketbase/models/settings"
 	"github.com/pocketbase/pocketbase/tools/mailer"
 )
 
@@ -12,9 +13,10 @@ func TestNewBaseApp(t *testing.T) {
 	defer os.RemoveAll(testDataDir)
 
 	app := NewBaseApp(BaseAppConfig{
-		DataDir:       testDataDir,
-		EncryptionEnv: "test_env",
-		IsDebug:       true,
+		DataDir:         testDataDir,
+		EncryptionEnv:   "test_env",
+		IsDebug:         true,
+		ServiceSettings: settings.New(),
 	})
 
 	if app.dataDir != testDataDir {
@@ -47,9 +49,10 @@ func TestBaseAppBootstrap(t *testing.T) {
 	defer os.RemoveAll(testDataDir)
 
 	app := NewBaseApp(BaseAppConfig{
-		DataDir:       testDataDir,
-		EncryptionEnv: "pb_test_env",
-		IsDebug:       false,
+		DataDir:         testDataDir,
+		EncryptionEnv:   "pb_test_env",
+		IsDebug:         false,
+		ServiceSettings: settings.New(),
 	})
 	defer app.ResetBootstrapState()
 
@@ -129,9 +132,10 @@ func TestBaseAppGetters(t *testing.T) {
 	defer os.RemoveAll(testDataDir)
 
 	app := NewBaseApp(BaseAppConfig{
-		DataDir:       testDataDir,
-		EncryptionEnv: "pb_test_env",
-		IsDebug:       false,
+		DataDir:         testDataDir,
+		EncryptionEnv:   "pb_test_env",
+		IsDebug:         false,
+		ServiceSettings: settings.New(),
 	})
 	defer app.ResetBootstrapState()
 
@@ -189,9 +193,10 @@ func TestBaseAppNewMailClient(t *testing.T) {
 	defer os.RemoveAll(testDataDir)
 
 	app := NewBaseApp(BaseAppConfig{
-		DataDir:       testDataDir,
-		EncryptionEnv: "pb_test_env",
-		IsDebug:       false,
+		DataDir:         testDataDir,
+		EncryptionEnv:   "pb_test_env",
+		IsDebug:         false,
+		ServiceSettings: settings.New(),
 	})
 
 	client1 := app.NewMailClient()
@@ -212,9 +217,10 @@ func TestBaseAppNewFilesystem(t *testing.T) {
 	defer os.RemoveAll(testDataDir)
 
 	app := NewBaseApp(BaseAppConfig{
-		DataDir:       testDataDir,
-		EncryptionEnv: "pb_test_env",
-		IsDebug:       false,
+		DataDir:         testDataDir,
+		EncryptionEnv:   "pb_test_env",
+		IsDebug:         false,
+		ServiceSettings: settings.New(),
 	})
 
 	// local
@@ -242,9 +248,10 @@ func TestBaseAppNewBackupsFilesystem(t *testing.T) {
 	defer os.RemoveAll(testDataDir)
 
 	app := NewBaseApp(BaseAppConfig{
-		DataDir:       testDataDir,
-		EncryptionEnv: "pb_test_env",
-		IsDebug:       false,
+		DataDir:         testDataDir,
+		EncryptionEnv:   "pb_test_env",
+		IsDebug:         false,
+		ServiceSettings: settings.New(),
 	})
 
 	// local

--- a/pocketbase.go
+++ b/pocketbase.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/pocketbase/pocketbase/cmd"
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/models/settings"
 	"github.com/pocketbase/pocketbase/tools/list"
 	"github.com/spf13/cobra"
 )
@@ -55,6 +56,9 @@ type Config struct {
 	DataMaxIdleConns int // default to core.DefaultDataMaxIdleConns
 	LogsMaxOpenConns int // default to core.DefaultLogsMaxOpenConns
 	LogsMaxIdleConns int // default to core.DefaultLogsMaxIdleConns
+
+	// optional Application configuration
+	ServiceSettings *settings.Settings
 }
 
 // New creates a new PocketBase instance with the default configuration.
@@ -85,6 +89,11 @@ func NewWithConfig(config Config) *PocketBase {
 	if config.DefaultDataDir == "" {
 		baseDir, _ := inspectRuntime()
 		config.DefaultDataDir = filepath.Join(baseDir, "pb_data")
+	}
+
+	// initialize a default setting
+	if config.ServiceSettings == nil {
+		config.ServiceSettings = settings.New()
 	}
 
 	pb := &PocketBase{
@@ -119,6 +128,7 @@ func NewWithConfig(config Config) *PocketBase {
 		DataMaxIdleConns: config.DataMaxIdleConns,
 		LogsMaxOpenConns: config.LogsMaxOpenConns,
 		LogsMaxIdleConns: config.LogsMaxIdleConns,
+		ServiceSettings:  config.ServiceSettings,
 	})}
 
 	// hide the default help command (allow only `--help` flag)

--- a/tests/app.go
+++ b/tests/app.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/models/settings"
 	"github.com/pocketbase/pocketbase/tools/mailer"
 )
 
@@ -95,9 +96,10 @@ func NewTestApp(optTestDataDir ...string) (*TestApp, error) {
 	}
 
 	app := core.NewBaseApp(core.BaseAppConfig{
-		DataDir:       tempDir,
-		EncryptionEnv: "pb_test_env",
-		IsDebug:       false,
+		DataDir:         tempDir,
+		EncryptionEnv:   "pb_test_env",
+		IsDebug:         false,
+		ServiceSettings: settings.New(),
 	})
 
 	// load data dir and db connections


### PR DESCRIPTION
When used in the form of framework, setting can be delivered at the part where pocketbase is directly executed.
(I'm a bit concerned because I think I put it in too directly)

added ServiceSettings field into Config struct,
And when calling app.NewWithConfig(), I modified it so that I can hand over the settings information to that field.

Please let me know if there is another good way. I'll follow that.