### PR TITLE
Make `@request.query` and `@request.headers` fields work on realtime rules

### DIFF
--- a/apis/middlewares.go
+++ b/apis/middlewares.go
@@ -24,6 +24,8 @@ const (
 	ContextAdminKey      string = "admin"
 	ContextAuthRecordKey string = "authRecord"
 	ContextCollectionKey string = "collection"
+	ContextQueryKey      string = "query"
+	ContextHeadersKey    string = "headers"
 )
 
 // RequireGuestOnly middleware requires a request to NOT have a valid


### PR DESCRIPTION
The [docs](https://pocketbase.io/docs/api-realtime/) state that

> When you subscribe to an entire collection, the collection's ListRule will be used to determine whether the subscriber has access to receive the event message.

however headers and query fields are not currently being populated, making ListRules behave differently on realtime queries.
should fix #2514.

note: the SDKs don't support query and headers in subscriptions yet, so to test the feature i used a custom http client to inject headers/query params:

```dart
class MyClient extends http.BaseClient {
  final http.Client _httpClient = http.Client();
  MyClient();
  @override
  Future<http.StreamedResponse> send(http.BaseRequest r0) {
    const inject = <String, String>{
      "foo": "bar"
    };
    var request = http.Request(
      r0.method,
      r0.url.replace(queryParameters: {...r0.url.queryParameters, ...inject}),
    );
    if (r0 is http.Request) {
      request.body = r0.body;      
      request.encoding = r0.encoding;      
    }
    request.headers.addAll({ ...r0.headers, ...inject });
    return _httpClient.send(request);
  }
}
```