### PR TITLE
feat: ignore workflow run when only *.md file changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,11 @@ name: basebuild
 
 on:
   pull_request:
+    paths-ignore:
+      - "*.md"
   push:
+    paths-ignore:
+      - "*.md"
 
 jobs:
   goreleaser:
@@ -21,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.21.3'
+          go-version: ">=1.21.3"
 
       # This step usually is not needed because the /ui/dist is pregenerated locally
       # but its here to ensure that each release embeds the latest admin ui artifacts.


### PR DESCRIPTION
The most recent workflow runs are only triggered due to change in Readme.md file, if i am not mistaken their is a limit (quota) for workflow run time for organization, and these workflow run do not give any benefits, so we can ignore workflow runs when only `*.md` files are changed. 

This PR change the workflow file to ignore the workflow run when only `*.md` files like `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md`, `LICENSE.md` and `README.md` are changed.

![image](https://github.com/pocketbase/pocketbase/assets/82411321/f8c634f5-a033-4695-ba7a-509d9cfaa0e0)
