### PR TITLE
Relax OAuth2 RedirectUrl validation

### DIFF
--- a/forms/record_oauth2_login.go
+++ b/forms/record_oauth2_login.go
@@ -7,10 +7,8 @@ import (
 	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/daos"
-	"github.com/pocketbase/pocketbase/forms/validators"
 	"github.com/pocketbase/pocketbase/models"
 	"github.com/pocketbase/pocketbase/tools/auth"
 	"github.com/pocketbase/pocketbase/tools/security"

--- a/forms/record_oauth2_login.go
+++ b/forms/record_oauth2_login.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-ozzo/ozzo-validation/v4/is"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/daos"
+	"github.com/pocketbase/pocketbase/forms/validators"
 	"github.com/pocketbase/pocketbase/models"
 	"github.com/pocketbase/pocketbase/tools/auth"
 	"github.com/pocketbase/pocketbase/tools/security"
@@ -89,7 +90,7 @@ func (form *RecordOAuth2Login) Validate() error {
 		validation.Field(&form.Provider, validation.Required, validation.By(form.checkProviderName)),
 		validation.Field(&form.Code, validation.Required),
 		validation.Field(&form.CodeVerifier, validation.Required),
-		validation.Field(&form.RedirectUrl, validation.Required, is.URL),
+		validation.Field(&form.RedirectUrl, validation.Required),
 	)
 }
 


### PR DESCRIPTION
Hey, first of all thanks for making PocketBase! 

I encountered an issue with OAuth2 when implementing auth in iOS. Current RedirectUrl validation is too restrictive and doesn't allow custom url schemes, which is needed for native apps.

I think it's best to disable that validation on the PocketBase side, because it's not really necessary there. Let the OAuth provider handle that instead in their own way.