### PR TITLE
WIP: Limit Thumbnail Generation Concurrency

### DIFF
--- a/apis/file_test.go
+++ b/apis/file_test.go
@@ -385,3 +385,7 @@ func TestFileDownload(t *testing.T) {
 		scenario.Test(t)
 	}
 }
+
+func BenchmarkThumbGen(b *testing.B) {
+
+}

--- a/apis/file_test.go
+++ b/apis/file_test.go
@@ -385,7 +385,3 @@ func TestFileDownload(t *testing.T) {
 		scenario.Test(t)
 	}
 }
-
-func BenchmarkThumbGen(b *testing.B) {
-
-}


### PR DESCRIPTION
This should fix the issue described in #3759. I tested this solution in my PB deployment and it did not run out of memory anymore. 

This solution does not use a separate Worker-Pool, rather it just blocks the request handler if too many thumbnails are generated at the same time. I think this is the simpler approach. 

It will also be easier to remove the semaphore in case this fix would be replaced by a more general solution in the new version FS abstraction (like limiting the number of open files or the number of bytes stored in memory). 

The limit should probably be configurable. @ganigeorgiev do you think I should read the Env-Variable `MAX_THUMBNAIL_CONCURRENCY`?




