### PR TITLE
nit: replacing redundant 'JWT token' with 'JWT'

### DIFF
--- a/daos/admin.go
+++ b/daos/admin.go
@@ -46,9 +46,9 @@ func (dao *Dao) FindAdminByEmail(email string) (*models.Admin, error) {
 	return model, nil
 }
 
-// FindAdminByToken finds the admin associated with the provided JWT token.
+// FindAdminByToken finds the admin associated with the provided JWT.
 //
-// Returns an error if the JWT token is invalid or expired.
+// Returns an error if the JWT is invalid or expired.
 func (dao *Dao) FindAdminByToken(token string, baseTokenKey string) (*models.Admin, error) {
 	// @todo consider caching the unverified claims
 	unverifiedClaims, err := security.ParseUnverifiedJWT(token)

--- a/daos/record.go
+++ b/daos/record.go
@@ -409,9 +409,9 @@ func (dao *Dao) IsRecordValueUnique(
 	return query.Row(&exists) == nil && !exists
 }
 
-// FindAuthRecordByToken finds the auth record associated with the provided JWT token.
+// FindAuthRecordByToken finds the auth record associated with the provided JWT.
 //
-// Returns an error if the JWT token is invalid, expired or not associated to an auth collection record.
+// Returns an error if the JWT is invalid, expired or not associated to an auth collection record.
 func (dao *Dao) FindAuthRecordByToken(token string, baseTokenKey string) (*models.Record, error) {
 	unverifiedClaims, err := security.ParseUnverifiedJWT(token)
 	if err != nil {

--- a/forms/apple_client_secret_create.go
+++ b/forms/apple_client_secret_create.go
@@ -33,7 +33,7 @@ type AppleClientSecretCreate struct {
 	// Usually wrapped within -----BEGIN PRIVATE KEY----- X -----END PRIVATE KEY-----.
 	PrivateKey string `form:"privateKey" json:"privateKey"`
 
-	// Duration specifies how long the generated JWT token should be considered valid.
+	// Duration specifies how long the generated JWT should be considered valid.
 	// The specified value must be in seconds and max 15777000 (~6months).
 	Duration int `form:"duration" json:"duration"`
 }

--- a/plugins/jsvm/internal/types/generated/types.d.ts
+++ b/plugins/jsvm/internal/types/generated/types.d.ts
@@ -5012,7 +5012,7 @@ namespace security {
  }
  interface parseUnverifiedJWT {
   /**
-   * ParseUnverifiedJWT parses JWT token and returns its claims
+   * ParseUnverifiedJWT parses JWT and returns its claims
    * but DOES NOT verify the signature.
    * 
    * It verifies only the exp, iat and nbf claims.
@@ -5021,13 +5021,13 @@ namespace security {
  }
  interface parseJWT {
   /**
-   * ParseJWT verifies and parses JWT token and returns its claims.
+   * ParseJWT verifies and parses JWT and returns its claims.
    */
   (token: string, verificationKey: string): jwt.MapClaims
  }
  interface newJWT {
   /**
-   * NewJWT generates and returns new HS256 signed JWT token.
+   * NewJWT generates and returns new HS256 signed JWT.
    */
   (payload: jwt.MapClaims, signingKey: string, secondsDuration: number): string
  }
@@ -5036,7 +5036,7 @@ namespace security {
    * Deprecated:
    * Consider replacing with NewJWT().
    * 
-   * NewToken is a legacy alias for NewJWT that generates a HS256 signed JWT token.
+   * NewToken is a legacy alias for NewJWT that generates a HS256 signed JWT.
    */
   (payload: jwt.MapClaims, signingKey: string, secondsDuration: number): string
  }
@@ -5582,7 +5582,7 @@ namespace forms {
    */
   privateKey: string
   /**
-   * Duration specifies how long the generated JWT token should be considered valid.
+   * Duration specifies how long the generated JWT should be considered valid.
    * The specified value must be in seconds and max 15777000 (~6months).
    */
   duration: number
@@ -11820,9 +11820,9 @@ namespace daos {
  }
  interface Dao {
   /**
-   * FindAdminByToken finds the admin associated with the provided JWT token.
+   * FindAdminByToken finds the admin associated with the provided JWT.
    * 
-   * Returns an error if the JWT token is invalid or expired.
+   * Returns an error if the JWT is invalid or expired.
    */
   findAdminByToken(token: string, baseTokenKey: string): (models.Admin)
  }
@@ -12230,9 +12230,9 @@ namespace daos {
  }
  interface Dao {
   /**
-   * FindAuthRecordByToken finds the auth record associated with the provided JWT token.
+   * FindAuthRecordByToken finds the auth record associated with the provided JWT.
    * 
-   * Returns an error if the JWT token is invalid, expired or not associated to an auth collection record.
+   * Returns an error if the JWT is invalid, expired or not associated to an auth collection record.
    */
   findAuthRecordByToken(token: string, baseTokenKey: string): (models.Record)
  }

--- a/tools/security/jwt.go
+++ b/tools/security/jwt.go
@@ -3,11 +3,9 @@ package security
 import (
 	"errors"
 	"time"
-
-	"github.com/golang-jwt/jwt/v4"
 )
 
-// ParseUnverifiedJWT parses JWT token and returns its claims
+// ParseUnverifiedJWT parses JWT and returns its claims
 // but DOES NOT verify the signature.
 //
 // It verifies only the exp, iat and nbf claims.
@@ -24,7 +22,7 @@ func ParseUnverifiedJWT(token string) (jwt.MapClaims, error) {
 	return claims, err
 }
 
-// ParseJWT verifies and parses JWT token and returns its claims.
+// ParseJWT verifies and parses JWT and returns its claims.
 func ParseJWT(token string, verificationKey string) (jwt.MapClaims, error) {
 	parser := jwt.NewParser(jwt.WithValidMethods([]string{"HS256"}))
 
@@ -42,7 +40,7 @@ func ParseJWT(token string, verificationKey string) (jwt.MapClaims, error) {
 	return nil, errors.New("Unable to parse token.")
 }
 
-// NewJWT generates and returns new HS256 signed JWT token.
+// NewJWT generates and returns new HS256 signed JWT.
 func NewJWT(payload jwt.MapClaims, signingKey string, secondsDuration int64) (string, error) {
 	seconds := time.Duration(secondsDuration) * time.Second
 
@@ -60,7 +58,7 @@ func NewJWT(payload jwt.MapClaims, signingKey string, secondsDuration int64) (st
 // Deprecated:
 // Consider replacing with NewJWT().
 //
-// NewToken is a legacy alias for NewJWT that generates a HS256 signed JWT token.
+// NewToken is a legacy alias for NewJWT that generates a HS256 signed JWT.
 func NewToken(payload jwt.MapClaims, signingKey string, secondsDuration int64) (string, error) {
 	return NewJWT(payload, signingKey, secondsDuration)
 }

--- a/tools/security/jwt_test.go
+++ b/tools/security/jwt_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestParseUnverifiedJWT(t *testing.T) {
-	// invalid formatted JWT token
+	// invalid formatted JWT
 	result1, err1 := security.ParseUnverifiedJWT("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCJ9")
 	if err1 == nil {
 		t.Error("Expected error got nil")
@@ -17,7 +17,7 @@ func TestParseUnverifiedJWT(t *testing.T) {
 		t.Error("Expected no parsed claims, got", result1)
 	}
 
-	// properly formatted JWT token with INVALID claims
+	// properly formatted JWT with INVALID claims
 	// {"name": "test", "exp": 1516239022}
 	result2, err2 := security.ParseUnverifiedJWT("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCIsImV4cCI6MTUxNjIzOTAyMn0.xYHirwESfSEW3Cq2BL47CEASvD_p_ps3QCA54XtNktU")
 	if err2 == nil {
@@ -27,7 +27,7 @@ func TestParseUnverifiedJWT(t *testing.T) {
 		t.Errorf("Expected to have 2 claims, got %v", result2)
 	}
 
-	// properly formatted JWT token with VALID claims
+	// properly formatted JWT with VALID claims
 	// {"name": "test"}
 	result3, err3 := security.ParseUnverifiedJWT("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCJ9.ml0QsTms3K9wMygTu41ZhKlTyjmW9zHQtoS8FUsCCjU")
 	if err3 != nil {
@@ -45,14 +45,14 @@ func TestParseJWT(t *testing.T) {
 		expectError  bool
 		expectClaims jwt.MapClaims
 	}{
-		// invalid formatted JWT token
+		// invalid formatted JWT
 		{
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCJ9",
 			"test",
 			true,
 			nil,
 		},
-		// properly formatted JWT token with INVALID claims and INVALID secret
+		// properly formatted JWT with INVALID claims and INVALID secret
 		// {"name": "test", "exp": 1516239022}
 		{
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCIsImV4cCI6MTUxNjIzOTAyMn0.xYHirwESfSEW3Cq2BL47CEASvD_p_ps3QCA54XtNktU",
@@ -60,7 +60,7 @@ func TestParseJWT(t *testing.T) {
 			true,
 			nil,
 		},
-		// properly formatted JWT token with INVALID claims and VALID secret
+		// properly formatted JWT with INVALID claims and VALID secret
 		// {"name": "test", "exp": 1516239022}
 		{
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCIsImV4cCI6MTUxNjIzOTAyMn0.xYHirwESfSEW3Cq2BL47CEASvD_p_ps3QCA54XtNktU",
@@ -68,7 +68,7 @@ func TestParseJWT(t *testing.T) {
 			true,
 			nil,
 		},
-		// properly formatted JWT token with VALID claims and INVALID secret
+		// properly formatted JWT with VALID claims and INVALID secret
 		// {"name": "test", "exp": 1898636137}
 		{
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCIsImV4cCI6MTg5ODYzNjEzN30.gqRkHjpK5s1PxxBn9qPaWEWxTbpc1PPSD-an83TsXRY",
@@ -76,7 +76,7 @@ func TestParseJWT(t *testing.T) {
 			true,
 			nil,
 		},
-		// properly formatted EXPIRED JWT token with VALID secret
+		// properly formatted EXPIRED JWT with VALID secret
 		// {"name": "test", "exp": 1652097610}
 		{
 			"eyJhbGciOiJIUzI1NiJ9.eyJuYW1lIjoidGVzdCIsImV4cCI6OTU3ODczMzc0fQ.0oUUKUnsQHs4nZO1pnxQHahKtcHspHu4_AplN2sGC4A",
@@ -84,7 +84,7 @@ func TestParseJWT(t *testing.T) {
 			true,
 			nil,
 		},
-		// properly formatted JWT token with VALID claims and VALID secret
+		// properly formatted JWT with VALID claims and VALID secret
 		// {"name": "test", "exp": 1898636137}
 		{
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCIsImV4cCI6MTg5ODYzNjEzN30.gqRkHjpK5s1PxxBn9qPaWEWxTbpc1PPSD-an83TsXRY",
@@ -92,7 +92,7 @@ func TestParseJWT(t *testing.T) {
 			false,
 			jwt.MapClaims{"name": "test", "exp": 1898636137.0},
 		},
-		// properly formatted JWT token with VALID claims (without exp) and VALID secret
+		// properly formatted JWT with VALID claims (without exp) and VALID secret
 		// {"name": "test"}
 		{
 			"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoidGVzdCJ9.ml0QsTms3K9wMygTu41ZhKlTyjmW9zHQtoS8FUsCCjU",


### PR DESCRIPTION
"JWT" stands for "JSON web token" (https://datatracker.ietf.org/doc/html/rfc7519), so "JWT token" would mean "JSON web token token." This is a minor pet peeve of mine, so I feel it is my duty to fix this.