### PR TITLE
Update README.md with additional command necessary for installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ your own custom app specific business logic and still have a single portable exe
 
 ```sh
 # go 1.21+
+go mod init pocketbase
 go get github.com/pocketbase/pocketbase
 ```
 


### PR DESCRIPTION
When installing pocketbase with go version 'go1.22.0 linux/amd64' you get an error about not being able to find packages.  'go mod init xxxxx' is required before the go get command. 

I chose pocketbase as the default 'go mod init' but it may make sense to let the reader know they could use something else, like 'example.com/pocketbase' or 'go mod init $MODULENAME'.