### PR TITLE
Fix code-wrapper height for Firefox

### DIFF
--- a/ui/src/components/base/CodeBlock.svelte
+++ b/ui/src/components/base/CodeBlock.svelte
@@ -41,7 +41,6 @@
     .code-wrapper {
         display: block;
         width: 100%;
-        max-height: 100%;
         overflow: auto; /* fallback */
         overflow: overlay;
     }


### PR DESCRIPTION
When generating a log event as follows:

```go
app.Logger().WithGroup("update").Error("some error message", "arg1", "info here")
```

The line height in the admin UI appears too small in Firefox.

On the left is Firefox 123.0.1, and on the right is Chromium 122.0.6261.94:
![swappy-20240306_155535](https://github.com/pocketbase/pocketbase/assets/23456686/e6225292-ffdd-4e27-a6f9-fb116116c0d8)

Removing `max-height: 100%;` from the `code-wrapper` class will resolve this issue.

(Sorry, just minutes late for the 0.22.3 release 😄)