### PR TITLE
Update types.go

### DIFF
--- a/plugins/jsvm/internal/types/types.go
+++ b/plugins/jsvm/internal/types/types.go
@@ -96,7 +96,7 @@ declare function routerAdd(
  * ` + "```" + `js
  * routerUse((next) => {
  *     return (c) => {
- *         console.log(c.Path())
+ *         console.log(c.path())
  *         return next(c)
  *     }
  * })


### PR DESCRIPTION
JSVM docs show uppercase `c.Path()` for middleware. The docs should use lowercase `.path()`.