### PR TITLE
feat: allow the admin ui to be "detached"

### DIFF
--- a/ui/detached.go
+++ b/ui/detached.go
@@ -1,0 +1,13 @@
+//go:build detachableadmin
+
+package ui
+
+import (
+	"os"
+
+	"github.com/labstack/echo/v5"
+)
+
+func init() {
+	DistDirFS = echo.MustSubFS(os.DirFS(os.Getenv("PB_ADMIN_UI_DIR")), "dist")
+}

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -1,4 +1,5 @@
-// Package ui handles the PocketBase Admin frontend embedding.
+//go:build !detachableadmin
+
 package ui
 
 import (
@@ -10,5 +11,7 @@ import (
 //go:embed all:dist
 var distDir embed.FS
 
-// DistDirFS contains the embedded dist directory files (without the "dist" prefix)
-var DistDirFS = echo.MustSubFS(distDir, "dist")
+func init() {
+	// DistDirFS contains the embedded dist directory files (without the "dist" prefix)
+	DistDirFS = echo.MustSubFS(distDir, "dist")
+}

--- a/ui/fs.go
+++ b/ui/fs.go
@@ -1,0 +1,18 @@
+// Package ui handles the PocketBase Admin frontend, which can either be embedded
+// or detached from the main binary. This logic is handled by build tags, the
+// embedded version is enabled by default. To detach the Admin UI, build the
+// binary with the "detachableadmin" build tag. e.g. `go build -tags
+// detachableadmin`
+package ui
+
+import (
+	"io/fs"
+)
+
+// DistDirFS is designed to point to the dist directory of the Admin UI. This can
+// point to an embedded or detached directory depending on the build tags. The
+// embedded version is enabled by default, if providing a detached directory,
+// which is discoverable at runtime, use the PB_ADMIN_DIR environment variable to
+// specify the directory path. Note that the directory must contain a "dist"
+// directory containing the Admin UI files.
+var DistDirFS fs.FS


### PR DESCRIPTION
This change allows users to customize if the admin UI is embeded at build time or specified as a detached directory which exists outside the binary. This allows users to provide a customized admin UI provided at runtime. Additionally it offers the ability to reduce the binary size for users who do not care about running the admin UI in production.

The conditional embedding support is provided through build tags. By default the admin UI is embeded, users can specify a detached admin UI with by building the project with the `detachableadmin` build tag and specifying the directory for their detached admin UI in the `PB_ADMIN_UI_DIR` env variable.