### PR TITLE
fix(migratecmd): remove superfluous semicolon in generated migration files

### DIFF
--- a/plugins/migratecmd/migratecmd_test.go
+++ b/plugins/migratecmd/migratecmd_test.go
@@ -115,7 +115,7 @@ func init() {
 
 		return daos.New(db).SaveCollection(collection)
 	}, func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId("new_id")
 		if err != nil {
@@ -256,7 +256,7 @@ import (
 
 func init() {
 	m.Register(func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId("test123")
 		if err != nil {
@@ -512,7 +512,7 @@ import (
 
 func init() {
 	m.Register(func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId("test123")
 		if err != nil {
@@ -588,7 +588,7 @@ func init() {
 
 		return dao.SaveCollection(collection)
 	}, func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId("test123")
 		if err != nil {

--- a/plugins/migratecmd/templates.go
+++ b/plugins/migratecmd/templates.go
@@ -426,7 +426,7 @@ func init() {
 
 		return daos.New(db).SaveCollection(collection)
 	}, func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId(%q)
 		if err != nil {
@@ -465,7 +465,7 @@ import (
 
 func init() {
 	m.Register(func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId(%q)
 		if err != nil {
@@ -739,7 +739,7 @@ import (%s
 
 func init() {
 	m.Register(func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId(%q)
 		if err != nil {
@@ -750,7 +750,7 @@ func init() {
 
 		return dao.SaveCollection(collection)
 	}, func(db dbx.Builder) error {
-		dao := daos.New(db);
+		dao := daos.New(db)
 
 		collection, err := dao.FindCollectionByNameOrId(%q)
 		if err != nil {


### PR DESCRIPTION
Hello :wave: 
Just a quick pull request to remove an extra semicolon in Go migration files that I detected by running `golangci-lint --enable-all ./...` in my project (this was not a good idea). Feel free to ignore it as it's really not something that breaks anything. 

And thank you for the awesome project! :heart: 