### PR TITLE
removed redundant rand.Seed

### DIFF
--- a/tools/security/random.go
+++ b/tools/security/random.go
@@ -9,9 +9,7 @@ import (
 
 const defaultRandomAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
-func init() {
-	mathRand.Seed(time.Now().UnixNano())
-}
+
 
 // RandomString generates a cryptographically random string with the specified length.
 //


### PR DESCRIPTION
rand.Seed is deprecated, no reason to call the function in newer versions of go...