### PR TITLE
Implements #4936: Open a relation record in new tab

### DIFF
--- a/ui/src/components/records/RecordInfo.svelte
+++ b/ui/src/components/records/RecordInfo.svelte
@@ -52,7 +52,21 @@
             position: "left",
         }}
     />
-
+    {#if record && record.id && record.collectionId}
+        <a
+            href="/#/collections?collectionId={record.collectionId}&filter=&sort=-created&recordId={record.id}"
+            target="_blank"
+        >
+            <i
+                class="link-hint txt-sm ri-share-box-fill"
+                use:tooltip={{
+                    text: "Open Record In New Tab",
+                    class: "code",
+                    position: "top",
+                }}
+            />
+        </a>
+    {/if}
     {#each fileDisplayFields as name}
         {@const filenames = CommonHelper.toArray(record[name]).slice(0, 5)}
         {#each filenames as filename}

--- a/ui/src/components/records/RecordsList.svelte
+++ b/ui/src/components/records/RecordsList.svelte
@@ -431,7 +431,9 @@
                 <tr
                     tabindex="0"
                     class="row-handle"
-                    on:click={() => dispatch("select", record)}
+                    on:click={(e) => {
+                        if (!e.target.classList.contains("ri-share-box-fill")) dispatch("select", record);
+                    }}
                     on:keydown={(e) => {
                         if (e.code === "Enter") {
                             e.preventDefault();


### PR DESCRIPTION
I have tried to implement #4936. I have tested locally and it seems to work. Preventing the dispatch event on `row-handle` feels a bit hacky, I am open to suggestions.