### PR TITLE
feat: Set default file size MaxSize to be `5Mb`(was `5Mib`)

### DIFF
--- a/ui/src/components/collections/schema/SchemaFieldFile.svelte
+++ b/ui/src/components/collections/schema/SchemaFieldFile.svelte
@@ -39,7 +39,7 @@
     function loadDefaults() {
         field.options = {
             maxSelect: 1,
-            maxSize: 5242880,
+            maxSize: 5000000,
             thumbs: [],
             mimeTypes: [],
         };


### PR DESCRIPTION
Setting up pocketbase locally, I've discovered that the default value for the max size of uploaded files to be of `5242880`, the indication says "Must be in bytes." so I thought the default value would be in bytes (`5000000` Bytes = `MB`) the current value represent `5 MiB` which is in bits and not bytes (it equates to 5.242880 MB) 
I used [this converter](https://www.dr-lex.be/info-stuff/bytecalc.html) to convert from MiB to MB

It's a really small nitpick, I didn't check if the code actually uses bytes or bits, so it might be wiser to change the text underneath the input to say bits instead

<img width="223" alt="image" src="https://github.com/user-attachments/assets/5eafaad4-a000-4395-a08a-1f2de4228c53">