### PR TITLE
Exit with a non-zero code when command execution fails

### DIFF
--- a/pocketbase.go
+++ b/pocketbase.go
@@ -167,7 +167,10 @@ func (pb *PocketBase) Execute() error {
 	// execute the root command
 	go func() {
 		// note: leave to the commands to decide whether to print their error
-		pb.RootCmd.Execute()
+		err := pb.RootCmd.Execute()
+		if err != nil {
+			os.Exit(1)
+		}
 
 		done <- true
 	}()


### PR DESCRIPTION
Pocketbase currently returns a 0 exit code even if the command fails to execute.

For example, from `examples/base`:
```
$ go run main.go blah && echo "hello"
Error: unknown command "blah" for "main"
Run 'main --help' for usage.
hello
```

When the expected result is:
```
$ go run main.go blah && echo "hello"
Error: unknown command "blah" for "main"
Run 'main --help' for usage.
exit status 1
```


This pull request corrects that behavior.