### PR TITLE
Fix double quoted string literal

### DIFF
--- a/migrations/1679943781_add_indexes_column.go
+++ b/migrations/1679943781_add_indexes_column.go
@@ -68,7 +68,7 @@ func init() {
 			TableName string `db:"tbl_name"`
 		}
 
-		indexesQuery := db.NewQuery(`SELECT * FROM sqlite_master WHERE type = "index" and sql is not null`)
+		indexesQuery := db.NewQuery(`SELECT * FROM sqlite_master WHERE type = 'index' and sql is not null`)
 		rawIndexes := []indexInfo{}
 		if err := indexesQuery.All(&rawIndexes); err != nil {
 			return err


### PR DESCRIPTION
Here, `'index'` is a string literal value for the `"type"` column.

In standard SQL column names are double quoted, string literals are single quoted.

Double quoted string literals are an SQLite [misfeature](https://www.sqlite.org/quirks.html#dblquote) that my driver is disables by default.

Related: https://github.com/ncruces/go-sqlite3/issues/142