### PR TITLE
Replace deprecated Instagram Basic Display API login with new Instagram Login method Scope, URL and Fields

### DIFF
--- a/tools/auth/instagram.go
+++ b/tools/auth/instagram.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pocketbase/pocketbase/tools/types"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/instagram"
 )
 
 var _ Provider = (*Instagram)(nil)
@@ -25,16 +24,16 @@ func NewInstagramProvider() *Instagram {
 		ctx:         context.Background(),
 		displayName: "Instagram",
 		pkce:        true,
-		scopes:      []string{"user_profile"},
-		authUrl:     instagram.Endpoint.AuthURL,
-		tokenUrl:    instagram.Endpoint.TokenURL,
-		userApiUrl:  "https://graph.instagram.com/me?fields=id,username,account_type",
+		scopes:      []string{"instagram_business_basic"},
+		authUrl:     "https://www.instagram.com/oauth/authorize",
+		tokenUrl:    "https://api.instagram.com/oauth/access_token",
+		userApiUrl:  "https://graph.instagram.com/me?fields=id,username,account_type,user_id,name,profile_picture_url,followers_count,follows_count,media_count",
 	}}
 }
 
-// FetchAuthUser returns an AuthUser instance based on the Instagram's user api.
+// FetchAuthUser returns an AuthUser instance based on the Instagram's login fields.
 //
-// API reference: https://developers.facebook.com/docs/instagram-basic-display-api/reference/user#fields
+// API reference: https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/get-started#fields
 func (p *Instagram) FetchAuthUser(token *oauth2.Token) (*AuthUser, error) {
 	data, err := p.FetchRawUserData(token)
 	if err != nil {
@@ -46,6 +45,7 @@ func (p *Instagram) FetchAuthUser(token *oauth2.Token) (*AuthUser, error) {
 		return nil, err
 	}
 
+	// @note the extracted "id" is a app scoped id, to get the actual IG ID use the RawUser's map key "user_id"
 	extracted := struct {
 		Id       string `json:"id"`
 		Username string `json:"username"`

--- a/tools/auth/instagram.go
+++ b/tools/auth/instagram.go
@@ -25,7 +25,7 @@ func NewInstagramProvider() *Instagram {
 		displayName: "Instagram",
 		pkce:        true,
 		scopes:      []string{"instagram_business_basic"},
-		authUrl:     "https://www.instagram.com/oauth/authorize",
+		authUrl:     "https://www.instagram.com/oauth/authorize?enable_fb_login=0&force_authentication=1",
 		tokenUrl:    "https://api.instagram.com/oauth/access_token",
 		userApiUrl:  "https://graph.instagram.com/me?fields=id,username,account_type,user_id,name,profile_picture_url,followers_count,follows_count,media_count",
 	}}

--- a/tools/auth/instagram.go
+++ b/tools/auth/instagram.go
@@ -45,6 +45,11 @@ func (p *Instagram) FetchAuthUser(token *oauth2.Token) (*AuthUser, error) {
 		return nil, err
 	}
 
+	// include list of granted permissions to RawUser's payload
+	if permissions := token.Extra("permissions"); permissions != nil {
+		rawUser["permissions"] = permissions
+	}
+
 	// @note the extracted "id" is a app scoped id, to get the actual IG ID use the RawUser's map key "user_id"
 	extracted := struct {
 		Id       string `json:"id"`


### PR DESCRIPTION
Hi @ganigeorgiev 

Meta has announced that Instagram Basic Display API is being deprecated on December 4th, more info [here](https://developers.facebook.com/blog/post/2024/09/04/update-on-instagram-basic-display-api/).

The replacement is now Instagram API with Instagram Login, more info [here](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login), or use the Facebook provider instead depending on the required use cases, more info [here](https://developers.facebook.com/docs/instagram-platform/instagram-api-with-instagram-login/migration-guide#should-you-migrate-your-app). 

Since the provider I contributed with before was mostly used to login using the deprecated scope, and it was missing some fields that are now available in the new method I have created this PR to update it.

Please note that if someone is still using this provider for Instagram Basic Display API to login, they should still be able to, however they may need to explicitly ~~`SetScopes` of the `ProviderClient` from the `OnRecordBeforeAuthWithOAuth2Request` hook as the default has changed.~~ set the `scopes` property when initiating auth collection with the SDK's `authWithOAuth2` as per [docs](https://pocketbase.io/docs/authentication/#oauth2-integration).

Let me know if you have any questions?