### PR TITLE
Migrate golang-jwt from v4 to v5.

### DIFF
--- a/forms/apple_client_secret_create.go
+++ b/forms/apple_client_secret_create.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/core"
 )
 

--- a/forms/apple_client_secret_create_test.go
+++ b/forms/apple_client_secret_create_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/forms"
 	"github.com/pocketbase/pocketbase/tests"
 )

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/ganigeorgiev/fexpr v0.4.1
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/goccy/go-json v0.10.3
-	github.com/golang-jwt/jwt/v4 v4.5.0
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/labstack/echo/v5 v5.0.0-20230722203903-ec5b858dab61
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/pocketbase/dbx v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpv
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/goccy/go-json v0.10.3 h1:KZ5WoDbxAIgm2HNbYckL0se1fHD6rz5j4ywS6ebzDqA=
 github.com/goccy/go-json v0.10.3/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
-github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
-github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/tokens/admin.go
+++ b/tokens/admin.go
@@ -1,7 +1,7 @@
 package tokens
 
 import (
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/models"
 	"github.com/pocketbase/pocketbase/tools/security"

--- a/tokens/record.go
+++ b/tokens/record.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"errors"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/models"
 	"github.com/pocketbase/pocketbase/tools/security"

--- a/tools/auth/apple.go
+++ b/tools/auth/apple.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/tools/types"
 	"github.com/spf13/cast"
 	"golang.org/x/oauth2"
@@ -142,11 +142,13 @@ func (p *Apple) parseAndVerifyIdToken(idToken string) (jwt.MapClaims, error) {
 
 	// validate common claims per https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user#3383769
 	// ---
-	if !claims.VerifyIssuer("https://appleid.apple.com", true) {
+	v := jwt.NewValidator(jwt.WithIssuer("https://appleid.apple.com"), jwt.WithAudience(p.clientId))
+
+	if err = v.Validate(claims); err != nil {
 		return nil, errors.New("iss must be https://appleid.apple.com")
 	}
 
-	if !claims.VerifyAudience(p.clientId, true) {
+	if err = v.Validate(claims); err != nil  {
 		return nil, errors.New("aud must be the developer's client_id")
 	}
 

--- a/tools/security/jwt.go
+++ b/tools/security/jwt.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // ParseUnverifiedJWT parses JWT and returns its claims
@@ -12,13 +12,14 @@ import (
 //
 // It verifies only the exp, iat and nbf claims.
 func ParseUnverifiedJWT(token string) (jwt.MapClaims, error) {
+
 	claims := jwt.MapClaims{}
 
 	parser := &jwt.Parser{}
 	_, _, err := parser.ParseUnverified(token, claims)
 
 	if err == nil {
-		err = claims.Valid()
+		err = jwt.NewValidator().Validate(claims)
 	}
 
 	return claims, err

--- a/tools/security/jwt_test.go
+++ b/tools/security/jwt_test.go
@@ -3,7 +3,7 @@ package security_test
 import (
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/tools/security"
 )
 


### PR DESCRIPTION
I saw this task in the Roadmap as a draft (https://github.com/orgs/pocketbase/projects/2?pane=issue&itemId=30777925). It wasn't that hard to do the migration, as golang-jwt already provides a migration guide from 4 to 5. All the tests pass without any modification. I also ran the locally built binary with my current setup to see if there are any untested changes. All looks good.