### PR TITLE
fix: Get "": unsupported protocol scheme "" when AvatarURL is empty 

### DIFF
--- a/apis/record_auth_with_oauth2.go
+++ b/apis/record_auth_with_oauth2.go
@@ -236,7 +236,7 @@ func oauth2Submit(e *core.RecordAuthWithOAuth2RequestEvent, optExternalAuth *cor
 				oldCanAssignUsername(txApp, e.Collection, e.OAuth2User.Username) {
 				payload[e.Collection.OAuth2.MappedFields.Username] = e.OAuth2User.Username
 			}
-			if _, ok := payload[e.Collection.OAuth2.MappedFields.AvatarURL]; !ok && e.Collection.OAuth2.MappedFields.AvatarURL != "" {
+			if _, ok := payload[e.Collection.OAuth2.MappedFields.AvatarURL]; !ok && e.OAuth2User.AvatarURL != "" {
 				mappedField := e.Collection.Fields.GetByName(e.Collection.OAuth2.MappedFields.AvatarURL)
 				if mappedField != nil && mappedField.Type() == core.FieldTypeFile {
 					// download the avatar if the mapped field is a file


### PR DESCRIPTION
Hi Gani, when trying Sign in with Apple I kept getting: 
```
ERROR POST /api/collections/users/auth-with-oauth2
└─ Failed to authenticate.
   └─ Get "": unsupported protocol scheme ""
```
even after removing all the hooks to be sure I was still getting the error. So debugged for a while and figure out that this bit was erroring because AvatarURL is ""

```go
	avatarFile, err := func() (*filesystem.File, error) {
						ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
						defer cancel()
						return filesystem.NewFileFromURL(ctx, e.OAuth2User.AvatarURL)
					}()
```

I think is due to a typo in this check 			`if _, ok := payload[e.Collection.OAuth2.MappedFields.AvatarURL]; !ok && e.Collection.OAuth2.MappedFields.AvatarURL != "" ` you want to check that the authuser has an url not the mappedField 

I tired the change and works fine for both Apple and Google. 

(I may be totally wrong, just wanted to try to fix the issues myself instead of keep bothering you)

