### PR TITLE
Fix EmailTemplate Documentation

### DIFF
--- a/plugins/jsvm/internal/types/generated/types.d.ts
+++ b/plugins/jsvm/internal/types/generated/types.d.ts
@@ -18678,9 +18678,10 @@ namespace settings {
  interface EmailTemplate {
   /**
    * Resolve replaces the placeholder parameters in the current email
-   * template and returns its components as ready-to-use strings.
+   * template and returns its components as ready-to-use strings in an array. The first element 
+   * being the subject, second the body, and third the action URL.
    */
-  resolve(appName: string, appUrl: string, token: string): string
+  resolve(appName: string, appUrl: string, token: string): Array<string>
  }
 }
 


### PR DESCRIPTION
Updated return documentation to follow what is actually returned by the function.

I'm not 100% sure my typescript fix is correct. I ran into this today in the docs and thought I would at least bring it to your attention. Thanks