### PR TITLE
Add NewDateTime(t time.TIme) DateTime to avoid reflection for common usecase.

### DIFF
--- a/tools/types/datetime.go
+++ b/tools/types/datetime.go
@@ -16,12 +16,22 @@ func NowDateTime() DateTime {
 	return DateTime{t: time.Now()}
 }
 
+// NewDateTime creates a new DateTime from the provided time.Time
+func NewDateTime(t time.Time) DateTime {
+	return DateTime{t: t}
+}
+
 // ParseDateTime creates a new DateTime from the provided value
 // (could be [cast.ToTime] supported string, [time.Time], etc.).
 func ParseDateTime(value any) (DateTime, error) {
 	d := DateTime{}
 	err := d.Scan(value)
 	return d, err
+}
+
+// ParseTime creates a new DateTime from the provided time.Time
+func ParseTime(t time.Time) DateTime {
+	return DateTime{t: t}
 }
 
 // DateTime represents a [time.Time] instance in UTC that is wrapped

--- a/tools/types/datetime.go
+++ b/tools/types/datetime.go
@@ -29,11 +29,6 @@ func ParseDateTime(value any) (DateTime, error) {
 	return d, err
 }
 
-// ParseTime creates a new DateTime from the provided time.Time
-func ParseTime(t time.Time) DateTime {
-	return DateTime{t: t}
-}
-
 // DateTime represents a [time.Time] instance in UTC that is wrapped
 // and serialized using the app default date layout.
 type DateTime struct {

--- a/tools/types/datetime_test.go
+++ b/tools/types/datetime_test.go
@@ -17,6 +17,15 @@ func TestNowDateTime(t *testing.T) {
 	}
 }
 
+func TestNewDatetime(t *testing.T) {
+	nowTime := time.Now()
+	nowFormated := nowTime.UTC().Format("2006-01-02 15:04:05")
+	dt := db.NewDateTime(nowTime)
+	if !strings.Contains(dt.String(), nowFormated) {
+		t.Fatalf("Expected %q, got %q", nowFormated, dt.String())
+	}
+}
+
 func TestParseDateTime(t *testing.T) {
 	nowTime := time.Now().UTC()
 	nowDateTime, _ := types.ParseDateTime(nowTime)


### PR DESCRIPTION
Ive been using the DateTime type alot in pocketbase as its essential for managing the dates in the database.

My most common use case by far is just going from a standard GO time format to a DateTime format for the database.

Constantly going between the go time instance and the datetime instance for manipulating dates.

The only parsing function we have currently is the ParseDateTime(v any) function

I propose adding a function like

```
func NewDateTime(t time.Time) DateTime {
	return DateTime{t: t}
}
```

The thing with using ParseDateTime(v any)  is that we are forced into using reflection when we dont have to.

If we are doing the safe operation that is error free goin from ```.Time to types.DateTime```.  We still have to handle the error block 
(or at least feel compelled to, yes we could just do t, _ := ParseDateTime(t), but if a function returns an error i like to handle it, even if its impossible in this case when the value passed in is an time.Time value)

In this PR i added the function and a simple test. I tried to stay consistent with the other tests there.

Ive currently just copied this file into my codebase and added the file for myself but it could be a nice addition for other PB users :).

Its simplified alot of my date handling functions where I originally handled the error to realise when reading the scan function internals that no error can be thrown if I pass in a time.Time struct.