### PR TITLE
Add IDX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ The easiest way to interact with the API is to use one of the official SDK clien
 
 ## Overview
 
+<a href="https://idx.google.com/new?template=https://github.com/project-idx/community-templates/tree/main/pocketbase">
+  <img height="32" alt="Try in IDX" src="https://cdn.idx.dev/btn/try_dark_32.svg">
+</a>
+
 ### Use as standalone app
 
 You could download the prebuilt executable for your platform from the [Releases page](https://github.com/pocketbase/pocketbase/releases).


### PR DESCRIPTION
Created an IDX template to easily get started with PocketBase in the browser.

<a href="https://idx.google.com/new?template=https://github.com/project-idx/community-templates/tree/main/pocketbase">
  <img height="32" alt="Try in IDX" src="https://cdn.idx.dev/btn/try_dark_32.svg">
</a>

![Screenshot 2024-11-12 at 10 26 53 AM](https://github.com/user-attachments/assets/ae6f9c3a-c959-4fda-af79-2c2230e7cbd9)
![Screenshot 2024-11-12 at 10 30 40 AM](https://github.com/user-attachments/assets/1e4d8ede-e00f-420f-8b3b-32c9168e93e4)
