### PR TITLE
New template cache request option

### DIFF
--- a/plugins/jsvm/internal/types/generated/types.d.ts
+++ b/plugins/jsvm/internal/types/generated/types.d.ts
@@ -3332,17 +3332,17 @@ namespace filesystem {
  * ```
  * 	registry := template.NewRegistry()
  * 
- * 	html1, err := registry.LoadFiles([
+ * 	html1, err := registry.LoadFiles([]string{
  * 		// the files set wil be parsed only once and then cached
  * 		"layout.html",
  * 		"content.html",
- * 	]).Render(map[string]any{"name": "John"})
+ * 	}).Render(map[string]any{"name": "John"})
  * 
- * 	html2, err := registry.LoadFiles([
+ * 	html2, err := registry.LoadFiles([]string{
  * 		// reuse the already parsed and cached files set
  * 		"layout.html",
  * 		"content.html",
- * 	]).Render(map[string]any{"name": "Jane"})
+ * 	}).Render(map[string]any{"name": "Jane"})
  * ```
  */
 namespace template {

--- a/plugins/jsvm/internal/types/generated/types.d.ts
+++ b/plugins/jsvm/internal/types/generated/types.d.ts
@@ -135,10 +135,10 @@ declare var $app: PocketBase
  * Example:
  *
  * ```js
- * const html = $template.loadFiles(
+ * const html = $template.loadFiles([
  *     "views/layout.html",
  *     "views/content.html",
- * ).render({"name": "John"})
+ * ]).render({"name": "John"})
  * ```
  *
  * _Note that this method is available only in pb_hooks context._
@@ -3332,17 +3332,17 @@ namespace filesystem {
  * ```
  * 	registry := template.NewRegistry()
  * 
- * 	html1, err := registry.LoadFiles(
+ * 	html1, err := registry.LoadFiles([
  * 		// the files set wil be parsed only once and then cached
  * 		"layout.html",
  * 		"content.html",
- * 	).Render(map[string]any{"name": "John"})
+ * 	]).Render(map[string]any{"name": "John"})
  * 
- * 	html2, err := registry.LoadFiles(
+ * 	html2, err := registry.LoadFiles([
  * 		// reuse the already parsed and cached files set
  * 		"layout.html",
  * 		"content.html",
- * 	).Render(map[string]any{"name": "Jane"})
+ * 	]).Render(map[string]any{"name": "Jane"})
  * ```
  */
 namespace template {
@@ -3392,14 +3392,14 @@ namespace template {
    * 
    * There must be at least 1 filename specified.
    */
-  loadFiles(...filenames: string[]): (Renderer)
+  loadFiles(filenames: string[], requestCache?: boolean): (Renderer)
  }
  interface Registry {
   /**
    * LoadString caches (if not already) the specified inline string as a
    * single template and returns a ready to use Renderer instance.
    */
-  loadString(text: string): (Renderer)
+  loadString(text: string, requestCache?: boolean): (Renderer)
  }
  interface Registry {
   /**
@@ -3409,7 +3409,7 @@ namespace template {
    * There must be at least 1 file matching the provided globPattern(s)
    * (note that most file names serves as glob patterns matching themselves).
    */
-  loadFS(fsys: fs.FS, ...globPatterns: string[]): (Renderer)
+  loadFS(fsys: fs.FS, globPatterns: string[], requestCache?: boolean): (Renderer)
  }
  /**
   * Renderer defines a single parsed template.

--- a/plugins/jsvm/internal/types/types.go
+++ b/plugins/jsvm/internal/types/types.go
@@ -151,10 +151,10 @@ declare var $app: PocketBase
  * Example:
  *
  * ` + "```" + `js
- * const html = $template.loadFiles(
+ * const html = $template.loadFiles([
  *     "views/layout.html",
  *     "views/content.html",
- * ).render({"name": "John"})
+ * ]).render({"name": "John"})
  * ` + "```" + `
  *
  * _Note that this method is available only in pb_hooks context._

--- a/plugins/jsvm/jsvm.go
+++ b/plugins/jsvm/jsvm.go
@@ -424,6 +424,10 @@ func (p *plugin) watchHooks() error {
 			return nil
 		}
 
+		if p.app.IsDev() && entry.Name() == "views" {
+			return nil
+		}
+
 		return watcher.Add(path)
 	})
 	if dirsErr != nil {

--- a/tools/template/registry.go
+++ b/tools/template/registry.go
@@ -8,23 +8,23 @@
 //
 //	registry := template.NewRegistry()
 //
-//	html1, err := registry.LoadFiles([
+//	html1, err := registry.LoadFiles([]string{
 //		// the files set will be parsed only once and then cached
 //		"layout.html",
 //		"content.html",
-//	]).Render(map[string]any{"name": "John"})
+//	}).Render(map[string]any{"name": "John"})
 //
-//	html2, err := registry.LoadFiles([
+//	html2, err := registry.LoadFiles([]string{
 //		// reuse the already parsed and cached files set
 //		"layout.html",
 //		"content.html",
-//	]).Render(map[string]any{"name": "Jane"})
+//	}).Render(map[string]any{"name": "Jane"})
 //
-//	html3, err := registry.LoadFiles([
+//	html3, err := registry.LoadFiles([]string{
 //		// newly parsed files with cache update
 //		"layout.html",
 //		"content.html",
-//	], false).Render(map[string]any{"name": "Juan"})
+//	}, false).Render(map[string]any{"name": "Juan"})
 package template
 
 import (


### PR DESCRIPTION
Hi,

This PR aims to improve developer experience when working with templates rendering.

JSVM restart on changes and force-cache-only loading make development slow: see #3969.

I imagine as well that there could be some production mode edge cases where some template cache request options could be useful.

So i propose :
- A new cache request option on Load* methods to disable cache use per request
- A new ForceCache method to disable default registry systematic cache use
- A new ClearCache method to reset registry cache

However I am not sure if unwatching _views_ directory to deactivate JSVM reload while in dev mode is an appropriate solution. I made the modification because i think it's better than moving _views_ folder somewhere other than in `__hooks`.

**Implementation details:**

```go
registry := template.NewRegistry()

// Now first parameter is a []string
// Second parameter (cache use) is a bool and is optional
// Load* methods still caches (if not already) by default
html1, err := registry.LoadFiles([]string{
	"layout.html",
	"content.html",
} //, true
).Render(map[string]any{"name": "John"})


// Turn off cache use per request
// Files will be newly parsed and cache will be updated
html2, err := registry.LoadFiles([]string{
	"layout.html",
	"content.html",
}, false).Render(map[string]any{"name": "Jane"})


// Turn off registry default systematic reuse of already parsed and cached files
registry.ForceCache(false)


// With ForceCache(false) previously called, now you can invoke without bool option
html3, err := registry.LoadFiles([]string{
	"layout.html",
	"content.html",
}).Render(map[string]any{"name": "Juan"})


// New cache clearing method
registry.ClearCache()

``` 

With JSVM :
```javascript
const html = $template.loadFiles([
	"views/layout.html",
	"views/content.html",
]).render({"name": "John"})
``` 

`go test ./tools/template` is ok
