### PR TITLE
Fix (UI): do not show batch tab on view collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 - Minor UI fixes (fixed duplicate record control, removed duplicated id field in the record preview, hide Impersonate button for non-auth records, auto sort rate limit rules, etc.).
 
+- Fixed do not show batch tab in view docs panel (API Preview).
+
 
 ## v0.23.0-rc14
 

--- a/ui/src/components/collections/CollectionDocsPanel.svelte
+++ b/ui/src/components/collections/CollectionDocsPanel.svelte
@@ -84,6 +84,7 @@
         delete tabs.update;
         delete tabs.delete;
         delete tabs.realtime;
+        delete tabs.batch;
     } else {
         tabs = Object.assign({}, baseTabs);
     }


### PR DESCRIPTION
## Description

Batch tab would be shown in the docs panel for views.

## Bug

![Bildschirmfoto 2024-11-22 um 14 55 47](https://github.com/user-attachments/assets/d7d8f7a4-1c89-413a-a17d-12770655c9f7)

## After

![Bildschirmfoto 2024-11-22 um 14 55 38](https://github.com/user-attachments/assets/831e57be-f166-495f-ab8a-4c369b4d8529)
