### PR TITLE
Update Google OAuth provider to use the v2 userinfo endpoint

### DIFF
--- a/tools/auth/google.go
+++ b/tools/auth/google.go
@@ -34,7 +34,7 @@ func NewGoogleProvider() *Google {
 		},
 		authURL:     "https://accounts.google.com/o/oauth2/auth",
 		tokenURL:    "https://accounts.google.com/o/oauth2/token",
-		userInfoURL: "https://www.googleapis.com/oauth2/v1/userinfo",
+		userInfoURL: "https://www.googleapis.com/userinfo/v2/me",
 	}}
 }
 


### PR DESCRIPTION
I updated Google OAuth2 provider to use the v2 userinfo endpoint, based on this roadmap [item](https://github.com/orgs/pocketbase/projects/2/views/1?pane=issue&itemId=52875953).

Testing locally, the new integration works as expected.

