### PR TITLE
Update to JWT v5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ This will start a web server on `http://localhost:8090` with the embedded prebui
   make test
   ```
 
-- Run the linter - **golangci** ([see how to install](https://golangci-lint.run/usage/install/#local-installation)):
+- Run the linter - **golangci** ([see how to install](https://golangci-lint.run/welcome/install/#local-installation)):
 
   ```sh
   golangci-lint run -c ./golangci.yml ./...

--- a/core/record_tokens.go
+++ b/core/record_tokens.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/tools/security"
 )
 

--- a/forms/apple_client_secret_create.go
+++ b/forms/apple_client_secret_create.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/core"
 )
 

--- a/forms/apple_client_secret_create_test.go
+++ b/forms/apple_client_secret_create_test.go
@@ -9,7 +9,7 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/forms"
 	"github.com/pocketbase/pocketbase/tests"
 )

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.7
 	github.com/ganigeorgiev/fexpr v0.4.1
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
-	github.com/golang-jwt/jwt/v4 v4.5.1
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/pocketbase/dbx v1.10.1
 	github.com/pocketbase/tygoja v0.0.0-20241015175937-d6ff411a0f75
 	github.com/spf13/cast v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/go-sourcemap/sourcemap v2.1.4+incompatible/go.mod h1:F8jJfvm2KbVjc5Nq
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
-github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=

--- a/plugins/jsvm/binds.go
+++ b/plugins/jsvm/binds.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/dop251/goja"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"

--- a/tools/auth/apple.go
+++ b/tools/auth/apple.go
@@ -138,17 +138,10 @@ func (p *Apple) parseAndVerifyIdToken(idToken string) (jwt.MapClaims, error) {
 
 	// validate common claims per https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user#3383769
 	// ---
-	err = claims.Valid() // exp, iat, etc.
+	validator := jwt.NewValidator(jwt.WithIssuedAt(), jwt.WithIssuer("https://appleid.apple.com"), jwt.WithAudience(p.clientId))
+	err = validator.Validate(claims)
 	if err != nil {
 		return nil, err
-	}
-
-	if !claims.VerifyIssuer("https://appleid.apple.com", true) {
-		return nil, errors.New("iss must be https://appleid.apple.com")
-	}
-
-	if !claims.VerifyAudience(p.clientId, true) {
-		return nil, errors.New("aud must be the developer's client_id")
 	}
 
 	// validate id_token signature

--- a/tools/auth/apple.go
+++ b/tools/auth/apple.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/tools/types"
 	"github.com/spf13/cast"
 	"golang.org/x/oauth2"

--- a/tools/auth/oidc.go
+++ b/tools/auth/oidc.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/tools/types"
 	"github.com/spf13/cast"
 	"golang.org/x/oauth2"

--- a/tools/security/jwt.go
+++ b/tools/security/jwt.go
@@ -18,7 +18,7 @@ func ParseUnverifiedJWT(token string) (jwt.MapClaims, error) {
 	_, _, err := parser.ParseUnverified(token, claims)
 
 	if err == nil {
-		err = claims.Valid()
+		err = jwt.NewValidator(jwt.WithIssuedAt()).Validate(claims)
 	}
 
 	return claims, err

--- a/tools/security/jwt.go
+++ b/tools/security/jwt.go
@@ -4,8 +4,7 @@ import (
 	"errors"
 	"time"
 
-	// @todo update to v5
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // ParseUnverifiedJWT parses JWT and returns its claims

--- a/tools/security/jwt_test.go
+++ b/tools/security/jwt_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/pocketbase/pocketbase/tools/security"
 )
 


### PR DESCRIPTION
I migrated the [golang-jwt](https://github.com/golang-jwt/jwt) dependency from v4 to v5, according to their [Migration guide](https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md).

I'm new to contributing so, I'm not sure if I was supposed to discuss the issue beforehand or if it's welcome, but I saw it was on the [roadmap](https://github.com/orgs/pocketbase/projects/2/views/1?pane=issue&itemId=30777925)
