### PR TITLE
add geolocation field type `core.FieldPoint` and internal `types.Point`

### DIFF
--- a/core/field_point.go
+++ b/core/field_point.go
@@ -1,0 +1,135 @@
+package core
+
+import (
+	"context"
+	"fmt"
+
+	validation "github.com/go-ozzo/ozzo-validation/v4"
+	"github.com/pocketbase/pocketbase/core/validators"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func init() {
+	Fields[FieldTypePoint] = func() Field {
+		return &PointField{}
+	}
+}
+
+const FieldTypePoint = "point"
+
+var _ Field = (*PointField)(nil)
+
+// PointField defines "point" type field to store a single [types.Point] value.
+//
+// The respective zero record field value is the zero [types.Point].
+type PointField struct {
+	// Name (required) is the unique name of the field.
+	Name string `form:"name" json:"name"`
+
+	// Id is the unique stable field identifier.
+	//
+	// It is automatically generated from the name when adding to a collection FieldsList.
+	Id string `form:"id" json:"id"`
+
+	// System prevents the renaming and removal of the field.
+	System bool `form:"system" json:"system"`
+
+	// Hidden hides the field from the API response.
+	Hidden bool `form:"hidden" json:"hidden"`
+
+	// Presentable hints the Dashboard UI to use the underlying
+	// field record value in the relation preview label.
+	Presentable bool `form:"presentable" json:"presentable"`
+}
+
+// Type implements [Field.Type] interface method.
+func (f *PointField) Type() string {
+	return FieldTypeDate
+}
+
+// GetId implements [Field.GetId] interface method.
+func (f *PointField) GetId() string {
+	return f.Id
+}
+
+// SetId implements [Field.SetId] interface method.
+func (f *PointField) SetId(id string) {
+	f.Id = id
+}
+
+// GetName implements [Field.GetName] interface method.
+func (f *PointField) GetName() string {
+	return f.Name
+}
+
+// SetName implements [Field.SetName] interface method.
+func (f *PointField) SetName(name string) {
+	f.Name = name
+}
+
+// GetSystem implements [Field.GetSystem] interface method.
+func (f *PointField) GetSystem() bool {
+	return f.System
+}
+
+// SetSystem implements [Field.SetSystem] interface method.
+func (f *PointField) SetSystem(system bool) {
+	f.System = system
+}
+
+// GetHidden implements [Field.GetHidden] interface method.
+func (f *PointField) GetHidden() bool {
+	return f.Hidden
+}
+
+// SetHidden implements [Field.SetHidden] interface method.
+func (f *PointField) SetHidden(hidden bool) {
+	f.Hidden = hidden
+}
+
+// ColumnType implements [Field.ColumnType] interface method.
+func (f *PointField) ColumnType(app App) string {
+	return "TEXT DEFAULT '' NOT NULL"
+}
+
+// PrepareValue implements [Field.PrepareValue] interface method.
+func (f *PointField) PrepareValue(record *Record, raw any) (any, error) {
+	// ignore scan errors since the format may change between versions
+	// and to allow running db adjusting migrations
+	val, _ := types.ParseDateTime(raw)
+	return val, nil
+}
+
+// ValidateValue implements [Field.ValidateValue] interface method.
+func (f *PointField) ValidateValue(ctx context.Context, app App, record *Record) error {
+	val, ok := record.GetRaw(f.Name).(types.Point)
+	if !ok {
+		return validators.ErrUnsupportedValueType
+	}
+
+	lat := val.Lat()
+	if lat > 90 {
+		return fmt.Errorf("latitude cannot be >90, got %f", val.Lat())
+	}
+	if lat < -90 {
+		return fmt.Errorf("latitude cannot be <-90, got %f", val.Lat())
+	}
+
+	long := val.Long()
+	if long > 180 {
+		return fmt.Errorf("longitude cannot be >180, got %f", val.Lat())
+	}
+	if lat < -180 {
+		return fmt.Errorf("longitude cannot be <-180, got %f", val.Lat())
+	}
+
+	return nil
+}
+
+// ValidateSettings implements [Field.ValidateSettings] interface method.
+func (f *PointField) ValidateSettings(ctx context.Context, app App, collection *Collection) error {
+	return validation.ValidateStruct(f,
+		validation.Field(&f.Id, validation.By(DefaultFieldIdValidationRule)),
+		validation.Field(&f.Name, validation.By(DefaultFieldNameValidationRule)),
+	)
+}

--- a/core/field_point.go
+++ b/core/field_point.go
@@ -40,6 +40,11 @@ type PointField struct {
 	// Presentable hints the Dashboard UI to use the underlying
 	// field record value in the relation preview label.
 	Presentable bool `form:"presentable" json:"presentable"`
+
+	// ---
+
+	// Required will require the field value to be non-empty coordinate pair.
+	Required bool `form:"required" json:"required"`
 }
 
 // Type implements [Field.Type] interface method.
@@ -105,6 +110,15 @@ func (f *PointField) ValidateValue(ctx context.Context, app App, record *Record)
 	val, ok := record.GetRaw(f.Name).(types.Point)
 	if !ok {
 		return validators.ErrUnsupportedValueType
+	}
+
+	if val.IsEmpty() {
+		if f.Required {
+			if err := validation.Required.Validate(val); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	lat := val.Lat()

--- a/core/field_point_test.go
+++ b/core/field_point_test.go
@@ -1,0 +1,208 @@
+package core_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/core"
+	"github.com/pocketbase/pocketbase/tests"
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func TestPointFieldBaseMethods(t *testing.T) {
+	testFieldBaseMethods(t, core.FieldTypePoint)
+}
+
+func TestPointFieldColumnType(t *testing.T) {
+	app, _ := tests.NewTestApp()
+	defer app.Cleanup()
+
+	f := &core.PointField{}
+	expected := "TEXT DEFAULT '' NOT NULL"
+
+	if v := f.ColumnType(app); v != expected {
+		t.Fatalf("Expected\n%q\ngot\n%q", expected, v)
+	}
+}
+
+func TestPointFieldPrepareValue(t *testing.T) {
+	app, _ := tests.NewTestApp()
+	defer app.Cleanup()
+
+	f := &core.PointField{}
+	record := core.NewRecord(core.NewBaseCollection("test"))
+
+	scenarios := []struct {
+		raw      any
+		expected string
+	}{
+		{"", ""},
+		{"invalid", ""},
+		{"42.3631, -71.0574", "42.3631, -71.0574"},
+		{types.Point{}, ""},
+	}
+
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("%d_%#v", i, s.raw), func(t *testing.T) {
+			v, err := f.PrepareValue(record, s.raw)
+			if err != nil && s.expected != "" {
+				t.Fatal(err)
+			}
+
+			vPoint, ok := v.(types.Point)
+			if !ok {
+				t.Fatalf("Expected types.Point instance, got %T", v)
+			}
+
+			if vPoint.String() != s.expected {
+				t.Fatalf("Expected %v, got %v", s.expected, v)
+			}
+		})
+	}
+}
+
+func TestPointFieldValidateValue(t *testing.T) {
+	app, _ := tests.NewTestApp()
+	defer app.Cleanup()
+
+	collection := core.NewBaseCollection("test_collection")
+
+	scenarios := []struct {
+		name        string
+		field       *core.PointField
+		record      func() *core.Record
+		expectError bool
+	}{
+		{
+			"invalid raw value",
+			&core.PointField{Name: "test"},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				record.SetRaw("test", 123)
+				return record
+			},
+			true,
+		},
+		{
+			"empty field value (not required)",
+			&core.PointField{Name: "test"},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				record.SetRaw("test", types.Point{})
+				return record
+			},
+			false,
+		},
+		{
+			"empty field value (required)",
+			&core.PointField{Name: "test", Required: true},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				record.SetRaw("test", types.Point{})
+				return record
+			},
+			true,
+		},
+		{
+			"valid coordinate pair",
+			&core.PointField{Name: "test", Required: true},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				p, _ := types.ParsePoint("42.3631, -71.0574")
+				record.SetRaw("test", p)
+				return record
+			},
+			false,
+		},
+		{
+			"invalid latitude (>90)",
+			&core.PointField{Name: "test"},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				p, _ := types.ParsePoint("91, 0")
+				record.SetRaw("test", p)
+				return record
+			},
+			true,
+		},
+		{
+			"invalid latitude (<-90)",
+			&core.PointField{Name: "test"},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				p, _ := types.ParsePoint("-91, 0")
+				record.SetRaw("test", p)
+				return record
+			},
+			true,
+		},
+		{
+			"invalid longitude (>180)",
+			&core.PointField{Name: "test"},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				p, _ := types.ParsePoint("0, 181")
+				record.SetRaw("test", p)
+				return record
+			},
+			true,
+		},
+		{
+			"invalid longitude (<-180)",
+			&core.PointField{Name: "test"},
+			func() *core.Record {
+				record := core.NewRecord(collection)
+				p, _ := types.ParsePoint("0, -181")
+				record.SetRaw("test", p)
+				return record
+			},
+			true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			err := s.field.ValidateValue(context.Background(), app, s.record())
+
+			hasErr := err != nil
+			if hasErr != s.expectError {
+				t.Fatalf("Expected hasErr %v, got %v (%v)", s.expectError, hasErr, err)
+			}
+		})
+	}
+}
+
+func TestPointFieldValidateSettings(t *testing.T) {
+	testDefaultFieldIdValidation(t, core.FieldTypePoint)
+	testDefaultFieldNameValidation(t, core.FieldTypePoint)
+
+	app, _ := tests.NewTestApp()
+	defer app.Cleanup()
+
+	collection := core.NewBaseCollection("test_collection")
+
+	scenarios := []struct {
+		name         string
+		field        func() *core.PointField
+		expectErrors []string
+	}{
+		{
+			"valid settings",
+			func() *core.PointField {
+				return &core.PointField{
+					Id:   "test",
+					Name: "test",
+				}
+			},
+			[]string{},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			errs := s.field().ValidateSettings(context.Background(), app, collection)
+			tests.TestValidationErrors(t, errs, s.expectErrors)
+		})
+	}
+}

--- a/tools/types/point.go
+++ b/tools/types/point.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ParsePoint creates a new Point from the provided value
+func ParsePoint(value any) (Point, error) {
+	p := Point{}
+	err := p.Scan(value)
+	return p, err
+}
+
+// Point represents a geographic point on Earth,
+// serialized as a comma-separated pair of float64s.
+type Point struct {
+	lat  float64
+	long float64
+}
+
+// Lat returns the internal latitude value.
+func (p Point) Lat() float64 {
+	return p.lat
+}
+
+// Long returns the internal longitude value.
+func (p Point) Long() float64 {
+	return p.lat
+}
+
+// Equal reports whether the two points are equal.
+func (p Point) Equal(u Point) bool {
+	if p.lat == u.lat && p.long == u.long {
+		return true
+	}
+	return false
+}
+
+// String serializes the current point instance into a formatted coordinate pair.
+//
+// The zero value is serialized to `0.0,0.0` (latitude,longitude).
+func (p Point) String() string {
+	lat := p.Lat()
+	long := p.Long()
+	if lat == 0 && long == 0 {
+		return "0.0,0.0"
+	}
+	return fmt.Sprintf("%f,%f", lat, long)
+}
+
+// MarshalJSON implements the [json.Marshaler] interface.
+func (p Point) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + p.String() + `"`), nil
+}
+
+// UnmarshalJSON implements the [json.Unmarshaler] interface.
+func (p *Point) UnmarshalJSON(b []byte) error {
+	var raw string
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	return p.Scan(raw)
+}
+
+// Value implements the [driver.Valuer] interface.
+func (p Point) Value() (driver.Value, error) {
+	return p.String(), nil
+}
+
+// Scan implements [sql.Scanner] interface to scan the provided value
+// into the current DateTime instance.
+func (p *Point) Scan(value any) error {
+	switch v := value.(type) {
+	case []byte:
+		pair, err := parsePointString(string(v))
+		if err != nil {
+			return err
+		}
+		p.lat = pair[0]
+		p.lat = pair[1]
+	case string:
+		pair, err := parsePointString(string(v))
+		if err != nil {
+			return err
+		}
+		p.lat = pair[0]
+		p.lat = pair[1]
+	default:
+	}
+	return nil
+}
+
+func parsePointString(value string) ([2]float64, error) {
+	coords := strings.Split(value, ",")
+	if len(coords) != 2 {
+		return [2]float64{}, fmt.Errorf("improperly formed point, need length 2 got length %d", len(coords))
+	}
+	latString := coords[0]
+	longString := coords[1]
+	lat, err := strconv.ParseFloat(latString, 64)
+	if err != nil {
+		return [2]float64{}, err
+	}
+	long, err := strconv.ParseFloat(longString, 64)
+	if err != nil {
+		return [2]float64{}, err
+	}
+	return [2]float64{lat, long}, nil
+}

--- a/tools/types/point_test.go
+++ b/tools/types/point_test.go
@@ -1,0 +1,171 @@
+package types_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pocketbase/pocketbase/tools/types"
+)
+
+func TestParsePoint(t *testing.T) {
+	scenarios := []struct {
+		value    any
+		expected string
+	}{
+		{nil, ""},
+		{"", ""},
+		{"invalid", ""},
+		{"42.3631, -71.0574", "42.3631, -71.0574"},
+		{types.Point{}, ""},
+		{"38.8977,-77.0365", "38.8977, -77.0365"},
+		{[]byte("121.141414,-8.12"), "121.141414, -8.12"},
+	}
+
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("%d_%#v", i, s.value), func(t *testing.T) {
+			p, err := types.ParsePoint(s.value)
+			if err != nil && s.expected != "" {
+				t.Fatalf("Failed to parse %v: %v", s.value, err)
+			}
+			if p.String() != s.expected {
+				t.Fatalf("Expected %q, got %q", s.expected, p.String())
+			}
+		})
+	}
+}
+
+func TestPointLatLong(t *testing.T) {
+	t.Parallel()
+
+	lat := 42.3631
+	long := -71.0574
+	p, _ := types.ParsePoint(fmt.Sprintf("%f, %f", lat, long))
+
+	if p.Lat() != lat {
+		t.Fatalf("Expected lat %f, got %f", lat, p.Lat())
+	}
+
+	if p.Long() != long {
+		t.Fatalf("Expected long %f, got %f", long, p.Long())
+	}
+}
+
+func TestPointEqual(t *testing.T) {
+	t.Parallel()
+
+	p1, _ := types.ParsePoint("42.3631, -71.0574")
+	p2, _ := types.ParsePoint("42.3631, -71.0574")
+	p3, _ := types.ParsePoint("42.3632, -71.0574")
+	p4 := types.Point{}
+
+	scenarios := []struct {
+		a      types.Point
+		b      types.Point
+		expect bool
+	}{
+		{p1, p1, true},
+		{p1, p2, true},
+		{p1, p3, false},
+		{p4, p4, true},
+		{p1, p4, false},
+	}
+
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("equal_%d", i), func(t *testing.T) {
+			if v := s.a.Equal(s.b); v != s.expect {
+				t.Fatalf("Expected %v, got %v", s.expect, v)
+			}
+		})
+	}
+}
+
+func TestPointString(t *testing.T) {
+	p0 := types.Point{}
+	if p0.String() != "" {
+		t.Fatalf("Expected empty string for zero point, got %q", p0.String())
+	}
+
+	expected := "42.3631, -71.0574"
+	p1, _ := types.ParsePoint(expected)
+	if p1.String() != expected {
+		t.Fatalf("Expected %q, got %v", expected, p1)
+	}
+}
+
+func TestPointMarshalJSON(t *testing.T) {
+	scenarios := []struct {
+		point    string
+		expected string
+	}{
+		{"", `""`},
+		{"42.3631, -71.0574", `"42.3631, -71.0574"`},
+	}
+
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("%d_%s", i, s.point), func(t *testing.T) {
+			p, err := types.ParsePoint(s.point)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := p.MarshalJSON()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(result) != s.expected {
+				t.Fatalf("Expected %q, got %q", s.expected, string(result))
+			}
+		})
+	}
+}
+
+func TestPointUnmarshalJSON(t *testing.T) {
+	scenarios := []struct {
+		json     string
+		expected string
+	}{
+		{"", ""},
+		{"invalid_json", ""},
+		{"'123'", ""},
+		{`"42.3631, -71.0574"`, "42.3631, -71.0574"},
+		{`""`, ""},
+	}
+
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("%d_%s", i, s.json), func(t *testing.T) {
+			p := types.Point{}
+			p.UnmarshalJSON([]byte(s.json))
+
+			if p.String() != s.expected {
+				t.Fatalf("Expected %q, got %q", s.expected, p.String())
+			}
+		})
+	}
+}
+
+func TestPointValue(t *testing.T) {
+	scenarios := []struct {
+		value    any
+		expected string
+	}{
+		{"", ""},
+		{"invalid", ""},
+		{"42.3631, -71.0574", "42.3631, -71.0574"},
+	}
+
+	for i, s := range scenarios {
+		t.Run(fmt.Sprintf("%d_%v", i, s.value), func(t *testing.T) {
+			p, _ := types.ParsePoint(s.value)
+
+			result, err := p.Value()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if result != s.expected {
+				t.Fatalf("Expected %q, got %q", s.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`core.FieldPoint` is a field type "Point" that represents a decimal-degree latitude & longitude, serialized as a comma separated string containing a pair of float64s (i.e. `-23.12414, 124.52131`) that are stored in a new internal type, `types.Point` which stores the corresponding float64s. Using float64s gives us incredibly low complexity with a worst-case precision of approximately 3.16 nanometers (on Earth).

Geolocation queries are not yet implemented, but could be handled easily by the consumer. There would be significant value in adding simple point-based queries, though, and some discussion on how this is implemented would be necessary. Checking whether a point lies in/out of an array of points (i.e. a geofence) or in/out of a radius around a point would provide enough for the vast majority of use cases; both of these could be implemented in a handful of ways, though, so some input would be nice.

Point fields are not currently implemented in the UI. I haven't looked at this yet, but frontend is not my wheelhouse so I will likely need some help here.

Fixes #21 