### PR TITLE
Update jsvm recordAuthResponse type

### DIFF
--- a/plugins/jsvm/internal/types/generated/types.d.ts
+++ b/plugins/jsvm/internal/types/generated/types.d.ts
@@ -13591,7 +13591,7 @@ namespace apis {
    * Set authMethod to empty string if you want to ignore the MFA checks and the login alerts
    * (can be also adjusted additionally via the OnRecordAuthRequest hook).
    */
-  (e: core.RequestEvent, authRecord: core.Record, authMethod: string, meta: any): void
+  (e: core.RequestEvent, authRecord: core.Record, authMethod: string, meta?: any): void
  }
  interface enrichRecord {
   /**


### PR DESCRIPTION
Hi,

I updated `recordAuthResponse` type to make the last parameter _optional_, consistently with the usual function usage in the documentation.