### PR TITLE
fix XFF header typo

### DIFF
--- a/core/event_request_test.go
+++ b/core/event_request_test.go
@@ -17,7 +17,7 @@ func TestEventRequestRealIP(t *testing.T) {
 		"CF-Connecting-IP": {"1.2.3.4", "1.1.1.1"},
 		"Fly-Client-IP":    {"1.2.3.4", "1.1.1.2"},
 		"X-Real-IP":        {"1.2.3.4", "1.1.1.3,1.1.1.4"},
-		"X-Forward-For":    {"1.2.3.4", "invalid,1.1.1.5,1.1.1.6,invalid"},
+		"X-Forwarded-For":  {"1.2.3.4", "invalid,1.1.1.5,1.1.1.6,invalid"},
 	}
 
 	scenarios := []struct {
@@ -44,28 +44,28 @@ func TestEventRequestRealIP(t *testing.T) {
 		{
 			"trusted X-Real-IP (rightmost)",
 			headers,
-			[]string{"header1", "x-real-ip", "x-forward-for"},
+			[]string{"header1", "x-real-ip", "x-forwarded-for"},
 			false,
 			"1.1.1.4",
 		},
 		{
 			"trusted X-Real-IP (leftmost)",
 			headers,
-			[]string{"header1", "x-real-ip", "x-forward-for"},
+			[]string{"header1", "x-real-ip", "x-forwarded-for"},
 			true,
 			"1.1.1.3",
 		},
 		{
-			"trusted X-Forward-For (rightmost)",
+			"trusted X-Forwarded-For (rightmost)",
 			headers,
-			[]string{"header1", "x-forward-for"},
+			[]string{"header1", "x-forwarded-for"},
 			false,
 			"1.1.1.6",
 		},
 		{
-			"trusted X-Forward-For (leftmost)",
+			"trusted X-Forwarded-For (leftmost)",
 			headers,
-			[]string{"header1", "x-forward-for"},
+			[]string{"header1", "x-forwarded-for"},
 			true,
 			"1.1.1.5",
 		},

--- a/core/settings_model.go
+++ b/core/settings_model.go
@@ -530,7 +530,7 @@ type TrustedProxyConfig struct {
 
 	// UseLeftmostIP specifies to use the left-mostish IP from the trusted headers.
 	//
-	// Note that this could be insecure when used with X-Forward-For header
+	// Note that this could be insecure when used with X-Forwarded-For header
 	// because some proxies like AWS ELB allow users to prepend their own header value
 	// before appending the trusted ones.
 	UseLeftmostIP bool `form:"useLeftmostIP" json:"useLeftmostIP"`

--- a/plugins/jsvm/internal/types/generated/types.d.ts
+++ b/plugins/jsvm/internal/types/generated/types.d.ts
@@ -12660,7 +12660,7 @@ namespace core {
   /**
    * UseLeftmostIP specifies to use the left-mostish IP from the trusted headers.
    * 
-   * Note that this could be insecure when used with X-Forward-For header
+   * Note that this could be insecure when used with X-Forwarded-For header
    * because some proxies like AWS ELB allow users to prepend their own header value
    * before appending the trusted ones.
    */

--- a/ui/src/components/settings/TrustedProxyAccordion.svelte
+++ b/ui/src/components/settings/TrustedProxyAccordion.svelte
@@ -8,7 +8,7 @@
     import CommonHelper from "@/utils/CommonHelper";
     import { scale } from "svelte/transition";
 
-    const commonProxyHeaders = ["X-Forward-For", "Fly-Client-IP", "CF-Connecting-IP"];
+    const commonProxyHeaders = ["X-Forwarded-For", "Fly-Client-IP", "CF-Connecting-IP"];
 
     export let formSettings;
     export let healthData;


### PR DESCRIPTION
"X-Forward-For" should be `X-Forwarded-For`

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For