### PR TITLE
Update db.go

### DIFF
--- a/core/validators/db.go
+++ b/core/validators/db.go
@@ -64,7 +64,7 @@ func NormalizeUniqueIndexError(err error, tableOrAlias string, fieldNames []stri
 
 		for _, name := range fieldNames {
 			// blank space to unify multi-columns lookup
-			if strings.Contains(msg+" ", strings.ToLower(tableOrAlias+"."+name)) {
+			if strings.Contains(msg+" ", strings.ToLower(" "+tableOrAlias+"."+name+" ")) {
 				normalizedErrs[name] = validation.NewError("validation_not_unique", "Value must be unique")
 			}
 		}


### PR DESCRIPTION
Fixed a bug where multiple fields starts same.

I got two fields: price and price_id. If there is a problem with price_id field, then also price field matches and program incorrectly reports error at both fields. Adding spaces fixed my problem.