### PR TITLE
Ideas for busting cached template funcs

### DIFF
--- a/tools/template/registry.go
+++ b/tools/template/registry.go
@@ -112,6 +112,17 @@ func (r *Registry) LoadString(text string) *Renderer {
 	return found
 }
 
+// ReloadString caches the specified inline string as a single template and
+// returns a ready to use Renderer instance.
+func (r *Registry) ReloadString(text string) *Renderer {
+	// parse and cache (using the text as key)
+	tpl, err := template.New("").Funcs(r.funcs).Parse(text)
+	renderer := &Renderer{template: tpl, parseError: err}
+	r.cache.Set(text, renderer)
+
+	return renderer
+}
+
 // LoadFS caches (if not already) the specified fs and globPatterns
 // pair as single template and returns a ready to use Renderer instance.
 //


### PR DESCRIPTION
The code in this PR is not meant to be considered for an actual change, but merely serves to illustrate the issue I found and form the basis of discussion.
---
I ran into a very basic problme where I wanted to do something like this in a template:

```html
{{ if isAuthenticated }}
  <a href="/login">Login</a>
{{ else }}
  <a href="/login">Login</a>
{{ end }}
```

And to do that I thought a simple middleware like this would do the trick:

```go
func(e *core.RequestEvent) error {
  a.registry.AddFuncs(map[string]any{
    "isAuthenticated": func() bool {
      return e.Auth != nil
    },
  })
  
  return e.Next()
}
```

And this works, the first time around when you call `LoadFiles` in a handler, but then that is cached going forward, which means `isAuthenticated` won't return the correct value e.g. after you log out again and `e.Auth` is `nil`.
---
I've just modified `TestRegistryAddFuncs` to show this issue with `LoadString`, but since `LoadFiles` is similar, it has the same issue.

The workaround I have here is to bust the cache and reload the files, but I'm not sure it's the best approach either.

The core of the problem is the fact that `template.Template.Funcs`, as stated in the docs ~must be called before the template is parsed.~

Any better ideas?