### PR TITLE
Increase the default recursion level in ExpandRecords method

### DIFF
--- a/core/record_query_expand.go
+++ b/core/record_query_expand.go
@@ -37,7 +37,7 @@ func (app *BaseApp) ExpandRecords(records []*Record, expands []string, optFetchF
 	failed := map[string]error{}
 
 	for _, expand := range normalized {
-		if err := app.expandRecords(records, expand, optFetchFunc, 1); err != nil {
+		if err := app.expandRecords(records, expand, optFetchFunc, 6); err != nil {
 			failed[expand] = err
 		}
 	}


### PR DESCRIPTION
Hello!

Proposing to increase the default recursion level in golang code.
I've been trying to access some of the nested relations in go, unfortunately it seems to be not possible without this PR