### PR TITLE
Support multiline cast expressions in view

### DIFF
--- a/core/view.go
+++ b/core/view.go
@@ -215,7 +215,7 @@ func defaultViewField(name string) Field {
 	}
 }
 
-var castRegex = regexp.MustCompile(`(?i)^cast\s*\(.*\s+as\s+(\w+)\s*\)$`)
+var castRegex = regexp.MustCompile(`(?is)^cast\s*\(.*\s+as\s+(\w+)\s*\)$`)
 
 func parseQueryToFields(app App, selectQuery string) (map[string]*queryField, error) {
 	p := new(identifiersParser)

--- a/core/view_test.go
+++ b/core/view_test.go
@@ -395,6 +395,26 @@ func TestCreateViewFields(t *testing.T) {
 			},
 		},
 		{
+			"query with multiline casts",
+			`select
+				id,
+				CAST(
+					(
+						CASE
+							WHEN COUNT(a.id) = 1 THEN 21
+							WHEN COUNT(a.id) = 2 THEN 18
+							ELSE 0
+						END
+					) AS INT
+				) as cast_int
+			from demo1 a`,
+			false,
+			map[string]string{
+				"id":       core.FieldTypeText,
+				"cast_int": core.FieldTypeNumber,
+			},
+		},
+		{
 			"query with reserved auth collection fields",
 			`
 				select

--- a/core/view_test.go
+++ b/core/view_test.go
@@ -395,18 +395,30 @@ func TestCreateViewFields(t *testing.T) {
 			},
 		},
 		{
-			"query with multiline casts",
+			"query with multiline cast",
 			`select
 				id,
-				CAST(
+				cast(
 					(
-						CASE
-							WHEN COUNT(a.id) = 1 THEN 21
-							WHEN COUNT(a.id) = 2 THEN 18
-							ELSE 0
-						END
-					) AS INT
+						case
+							when count(a.id) = 1 then 21
+							when count(a.id) = 2 then 18
+							else 0
+						end
+					) as int
 				) as cast_int
+			from demo1 a`,
+			false,
+			map[string]string{
+				"id":       core.FieldTypeText,
+				"cast_int": core.FieldTypeNumber,
+			},
+		},
+		{
+			"query with case-insensitive and extra-spaced cast",
+			`select
+				id,
+				CaSt( a.id  aS iNt ) as cast_int
 			from demo1 a`,
 			false,
 			map[string]string{


### PR DESCRIPTION
Currently, if you insert a multiline cast expression in a view collection, it will not be recognised, and the field type will not be unknown.

One example of such query:
```sql
CAST(
  (ROW_NUMBER() OVER ()) AS INT
) as cast_int
```

This happens becase the regex is not processing newlines correctly. 
To fix this, we add one more option "s" (shorthand for singleline), so that dots and \s match correctly.

#### Testing
Added a new unit test in ./core/view_test.go
```bash
$ go test ./core/view_test.go
ok      command-line-arguments  0.535s
```
