### PR TITLE
Disable TLS when `--https=""`

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -27,9 +27,6 @@ func NewServeCommand(app core.App, showStartBanner bool) *cobra.Command {
 				if httpAddr == "" {
 					httpAddr = "0.0.0.0:80"
 				}
-				if httpsAddr == "" {
-					httpsAddr = "0.0.0.0:443"
-				}
 			} else {
 				if httpAddr == "" {
 					httpAddr = "127.0.0.1:8090"


### PR DESCRIPTION
According the argument description:

```
TCP address to listen for the HTTPS server
                          (if domain args are specified - default to 0.0.0.0:443, otherwise - default to empty string, aka. no TLS)
                          The incoming HTTP traffic also will be auto redirected to the HTTPS version
```

However, if set `--https=""`, the current code will force enabling TLS on `0.0.0.0:443`, which is different from the described behavior.
