### PR TITLE
Show 127.0.0.1 instead of 0.0.0.0 in start message

### DIFF
--- a/apis/serve.go
+++ b/apis/serve.go
@@ -275,8 +275,8 @@ func Serve(app core.App, config ServeConfig) error {
 		)
 
 		regular := color.New()
-		regular.Printf("├─ REST API:  %s\n", color.CyanString("%s/api/", baseURL))
-		regular.Printf("└─ Dashboard: %s\n", color.CyanString("%s/_/", baseURL))
+		regular.Printf("├─ REST API:  %s\n", color.CyanString("%s/api/", strings.ReplaceAll(baseURL, "0.0.0.0", "127.0.0.1")))
+		regular.Printf("└─ Dashboard: %s\n", color.CyanString("%s/_/", strings.ReplaceAll(baseURL, "0.0.0.0", "127.0.0.1")))
 	}
 
 	var serveErr error


### PR DESCRIPTION
During local development, we often mistakenly open the dashboard via the link `http://0.0.0.0:80/_/`. But what we actually want to open is `http://127.0.0.1:80/_/`. This PR fixes the link displayed in message. Note that the message `Server started at http://0.0.0.0:80` remains to be `0.0.0.0` to indicate currently listen address.

Before:
<img width="694" alt="image" src="https://github.com/user-attachments/assets/c4f79d08-5375-47c9-b897-4790847c13a7" />

After:
<img width="484" alt="image" src="https://github.com/user-attachments/assets/29afcf6a-2495-4db8-ad74-9c651068db14" />
