### PR TITLE
S3 Storage use default "bytes=0-" range instead of "" empty range

### DIFF
--- a/tools/filesystem/internal/s3blob/s3blob.go
+++ b/tools/filesystem/internal/s3blob/s3blob.go
@@ -199,8 +199,18 @@ func (drv *driver) NewRangeReader(ctx context.Context, key string, offset, lengt
 		byteRange = fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
 	}
 
-	reqOpt := func(req *http.Request) {
-		req.Header.Set("Range", byteRange)
+	var reqOpt func(*http.Request)
+
+	if byteRange != "" {
+		reqOpt = func(req *http.Request) {
+			req.Header.Set("Range", byteRange)
+		}
+	} else {
+		// Always set a range header, even for full reads
+		byteRange = "bytes=0-"
+		reqOpt = func(req *http.Request) {
+			req.Header.Set("Range", byteRange)
+		}
 	}
 
 	resp, err := drv.s3.GetObject(ctx, key, reqOpt)


### PR DESCRIPTION
First of all. What a fantastic project :-). You are an absolute beast.

## Changes

This PR changes from `Range` header equals `""` to `bytes=0-` for S3 storage driver.

## Backstory

I ran into an error with our S3 Storage provider (https://flow.swiss/object-storage, we have to use it due to data privacy reasons...). I assume they use `minio` hidden behind a `caddy` reverse proxy. 

This is the error I got:
```
416 InvalidRange: The requested range cannot be satisfied.
(RAW: <?xml version="1.0" encoding="UTF-8"?><Error><Code>InvalidRange</Code><Message>The requested range cannot be satisfied.</Message></Error>)
```

I wrote some local tests scripts. Range is fully supported by the provider. 

Now in the case where pocketbase requests the full file.

https://github.com/pocketbase/pocketbase/blob/88bb8c406e6cb49b81f57007b8511ccdccf80610/tools/filesystem/blob/bucket.go#L409-L411

The logic triggered results in a `Range` header equals `""`.

https://github.com/pocketbase/pocketbase/blob/88bb8c406e6cb49b81f57007b8511ccdccf80610/tools/filesystem/internal/s3blob/s3blob.go#L192-L200

In the `minio` test we can see the unsupported `range` equals `""` here:

https://github.com/minio/minio/blob/21409f112dc299966a3beca89ead13f5045ecc33/cmd/httprange_test.go#L62