### PR TITLE
add exit code

### DIFF
--- a/pocketbase.go
+++ b/pocketbase.go
@@ -167,7 +167,10 @@ func (pb *PocketBase) Start() error {
 	pb.RootCmd.AddCommand(cmd.NewSuperuserCommand(pb))
 	pb.RootCmd.AddCommand(cmd.NewServeCommand(pb, !pb.hideStartBanner))
 
-	return pb.Execute()
+	err := pb.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
 }
 
 // Execute initializes the application (if not already) and executes


### PR DESCRIPTION
Noticed this when superuser commands throw errors, the exit code is always 0. This sets the exit code to 1 if an error is returned.