### PR TITLE
fix: dummy id in ListApiDocs

### DIFF
--- a/ui/src/components/collections/docs/ListApiDocs.svelte
+++ b/ui/src/components/collections/docs/ListApiDocs.svelte
@@ -28,7 +28,7 @@
                     perPage: 30,
                     totalPages: 1,
                     totalItems: 2,
-                    items: [dummyRecord, Object.assign({}, dummyRecord, { id: dummyRecord + "2" })],
+                    items: [dummyRecord, Object.assign({}, dummyRecord, { id: dummyRecord.id + "2" })],
                 },
                 null,
                 2,


### PR DESCRIPTION
fixed a typo in one of the examples

<img width="1638" height="1356" alt="image" src="https://github.com/user-attachments/assets/fdd3479e-a741-4915-b1bb-8b3f616004b7" />
