### PR TITLE
Fixed typo in docs

### DIFF
--- a/core/settings_model.go
+++ b/core/settings_model.go
@@ -676,8 +676,8 @@ type RateLimitRule struct {
 
 	// Audience specifies the auth group the rule should apply for:
 	//   - ""      - both guests and authenticated users (default)
-	//   - "guest" - only for guests
-	//   - "auth"  - only for authenticated users
+	//   - "@guest" - only for guests
+	//   - "@auth"  - only for authenticated users
 	Audience string `form:"audience" json:"audience"`
 
 	// Duration specifies the interval (in seconds) per which to reset


### PR DESCRIPTION
Hi Gani!

While trying to add all the configuration as code in a migration file, I came across this typo that made me spend some time on why I got the error below on initialization despite using the correct types:

`rateLimits: (rules: (4: (audience: must be a valid value.); 5: (audience: must be a valid value.).).).`

On a closer look, it was just a typo in the comments. 

The JSVM should also be regenerated.

And thanks a lot for the great work you've done! It's an amazing project! :)