### PR TITLE
Separate syscall import with build constraints (WASM)

### DIFF
--- a/core/base.go
+++ b/core/base.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/fatih/color"
@@ -773,7 +772,7 @@ func (app *BaseApp) Restart() error {
 			}
 		}()
 
-		return syscall.Exec(execPath, os.Args, os.Environ())
+		return exec(execPath, os.Args, os.Environ())
 	})
 }
 

--- a/core/syscall.go
+++ b/core/syscall.go
@@ -1,0 +1,9 @@
+//go:build !(js && wasm)
+
+package core
+
+import "syscall"
+
+func exec(argv0 string, argv []string, envv []string) error {
+	return syscall.Exec(argv0, argv, envv)
+}

--- a/core/syscall_wasm.go
+++ b/core/syscall_wasm.go
@@ -1,0 +1,9 @@
+//go:build js && wasm
+
+package core
+
+import "errors"
+
+func exec(argv0 string, argv []string, envv []string) error {
+	return errors.ErrUnsupported
+}


### PR DESCRIPTION
Separating syscall import with build constraints allows Pocketbase core to be used for building to WASM. Compiling WASM build does not allow that `import "syscall"` appears anywhere within used source code files. This was the only real blocker for building to WASM that cannot be accounted for in the module consuming Pocketbase. See https://github.com/joas8211/pocketbase-wasm for the proof of concept.

Without these changes, the following error is logged on build:

```
# github.com/pocketbase/pocketbase/core
pocketbase/core/base.go:776:18: undefined: syscall.Exec
```