### PR TITLE
feat(schema): Merge scaffold indexes on collection type change

### DIFF
--- a/ui/src/components/collections/CollectionFieldsTab.svelte
+++ b/ui/src/components/collections/CollectionFieldsTab.svelte
@@ -145,6 +145,12 @@
         const blank = structuredClone($scaffolds[collection.type]);
         collection.fields = blank.fields;
 
+        // Merge existing indexes with the new type's scaffold defaults.
+        // Using a Set is a clean way to combine the arrays and prevent duplicates.
+        const oldIndexes = collection.indexes || [];
+        const newIndexes = blank.indexes || [];
+        collection.indexes = [...new Set([...oldIndexes, ...newIndexes])];
+
         for (let oldField of oldFields) {
             if (!oldField.system) {
                 continue;


### PR DESCRIPTION
Currently there is a bug when creating a new auth collection. The indexes from the scaffold are not correctly set. In the image below you should see 2 indexes but it shows as 0:
<img width="1901" height="896" alt="image" src="https://github.com/user-attachments/assets/8c819a4a-b659-4c97-93b9-cc45d779962c" />

this also leads to missing fields in the option tab (since these fields are derived from unique indexes):
<img width="1901" height="896" alt="image" src="https://github.com/user-attachments/assets/87009047-fcbc-464f-b530-b24ddb2d1720" />

however when you submit the collection without changing anything the indexes do get set somewhere: 
<img width="1901" height="896" alt="image" src="https://github.com/user-attachments/assets/63f22f0c-b826-48bc-8737-318ee279e723" />


i think the problem happens here: 

```
CollectionUpsertPanel.svelte line 280:

collection = Object.assign(structuredClone($scaffolds[t]), collection);
``` 

you overwrite the fields in ```$scaffolds``` with the fields from collection (which has 3 fields (id, updated, created), and index:[]), however because you bind the collection:                
 
```
CollectionUpsertPanel.svelte line 548:
<CollectionFieldsTab bind:collection />
 ```

the fields that are required from the auth collection are added in ```onTypeChange```, however the indexes required for auth are not. i added the code to merge them too. I think indexes are the only property that need to be added manully like this. 

This change adds and displays the indexes properly:

<img width="1901" height="896" alt="image" src="https://github.com/user-attachments/assets/abd0df97-a210-4cf0-9f70-9a765a4e9dc4" />
