### PR TITLE
add dark mode functionality to UI

### DIFF
--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -3,11 +3,13 @@
 
     import tooltip from "@/actions/tooltip";
     import Confirmation from "@/components/base/Confirmation.svelte";
+    import DarkModeToggle from "@/components/base/DarkModeToggle.svelte";
     import TinyMCE from "@/components/base/TinyMCE.svelte";
     import Toasts from "@/components/base/Toasts.svelte";
     import Toggler from "@/components/base/Toggler.svelte";
     import { appName, hideControls, pageTitle } from "@/stores/app";
     import { resetConfirmation } from "@/stores/confirmation";
+    import { darkMode } from "@/stores/darkMode";
     import { setErrors } from "@/stores/errors";
     import { superuser } from "@/stores/superuser";
     import ApiClient from "@/utils/ApiClient";
@@ -24,6 +26,11 @@
 
     $: if ($superuser?.id) {
         loadSettings();
+    }
+
+    // Initialize theme on app load
+    $: if (typeof window !== "undefined") {
+        document.documentElement.setAttribute("data-theme", $darkMode ? "dark" : "light");
     }
 
     function handleRouteLoading(e) {
@@ -125,6 +132,10 @@
                 </a>
             </nav>
 
+            <div class="sidebar-footer">
+                <DarkModeToggle />
+            </div>
+
             <div
                 tabindex="0"
                 role="button"
@@ -147,6 +158,10 @@
                         <i class="ri-shield-user-line" aria-hidden="true" />
                         <span class="txt">Manage superusers</span>
                     </a>
+                    <button type="button" class="dropdown-item closable" role="menuitem" on:click={darkMode.toggle}>
+                        <i class="{$darkMode ? 'ri-sun-line' : 'ri-moon-line'}" aria-hidden="true" />
+                        <span class="txt">{$darkMode ? 'Light mode' : 'Dark mode'}</span>
+                    </button>
                     <button type="button" class="dropdown-item closable" role="menuitem" on:click={logout}>
                         <i class="ri-logout-circle-line" aria-hidden="true" />
                         <span class="txt">Logout</span>
@@ -181,5 +196,12 @@
         padding: 10px;
         max-width: 200px;
         color: var(--txtHintColor);
+    }
+
+    .sidebar-footer {
+        margin-top: auto;
+        padding: 10px;
+        display: flex;
+        justify-content: center;
     }
 </style>

--- a/ui/src/components/base/DarkModeToggle.svelte
+++ b/ui/src/components/base/DarkModeToggle.svelte
@@ -1,0 +1,18 @@
+<script>
+    import { darkMode } from "@/stores/darkMode";
+    import tooltip from "@/actions/tooltip";
+</script>
+
+<button
+    type="button"
+    class="btn btn-circle btn-transparent btn-hint"
+    aria-label="Toggle dark mode"
+    use:tooltip={{ text: $darkMode ? "Switch to light mode" : "Switch to dark mode", position: "bottom" }}
+    on:click={darkMode.toggle}
+>
+    {#if $darkMode}
+        <i class="ri-sun-line" />
+    {:else}
+        <i class="ri-moon-line" />
+    {/if}
+</button>

--- a/ui/src/scss/_dark.scss
+++ b/ui/src/scss/_dark.scss
@@ -1,0 +1,395 @@
+// Dark mode color overrides
+
+:root[data-theme="dark"] {
+    --bodyColor: #1a1a24;
+    --baseColor: #2a2a34;
+    --baseAlt1Color: #3a3a44;
+    --baseAlt2Color: #4a4a54;
+    --baseAlt3Color: #5a5a64;
+    --baseAlt4Color: #6a6a74;
+    --txtPrimaryColor: #f8f9fa;
+    --txtHintColor: #a0a6ac;
+    --txtDisabledColor: #707070;
+    --primaryColor: #5499e8;
+
+    // Status colors for dark mode
+    --infoColor: #5499e8;
+    --infoAltColor: #1a3a5c;
+    --successColor: #32ad84;
+    --successAltColor: #0f3d2a;
+    --dangerColor: #e34562;
+    --dangerAltColor: #4a1a28;
+    --warningColor: #ff944d;
+    --warningAltColor: #5a3018;
+
+    --overlayColor: rgba(0, 0, 0, 0.6);
+    --tooltipColor: rgba(42, 42, 52, 0.95);
+    --shadowColor: rgba(0, 0, 0, 0.3);
+}
+
+// Dark mode button overrides
+:root[data-theme="dark"] {
+    .btn-secondary,
+    .btn-transparent,
+    .btn-outline {
+        &:before {
+            background: var(--baseAlt2Color);
+        }
+        &:hover,
+        &:focus-visible {
+            &:before {
+                background: var(--baseAlt3Color);
+            }
+        }
+        &:active,
+        &.active {
+            &:before {
+                background: var(--baseAlt4Color);
+            }
+        }
+    }
+
+    .btn-outline {
+        background: var(--baseColor);
+        border-color: var(--baseAlt3Color);
+        &:hover,
+        &:focus-visible {
+            border-color: var(--baseAlt4Color);
+        }
+    }
+
+    // Dark mode syntax highlighting for API preview
+    .prism-light {
+        code[class*="language-"],
+        pre[class*="language-"] {
+            color: #e6e6e6;
+            background: var(--baseAlt1Color);
+        }
+
+        :not(pre) > code[class*="language-"],
+        pre[class*="language-"] {
+            background: var(--baseAlt1Color);
+        }
+
+        .token.comment,
+        .token.prolog,
+        .token.doctype,
+        .token.cdata {
+            color: #7c7c7c;
+        }
+
+        .token.punctuation {
+            color: #c9c9c9;
+        }
+
+        .token.tag,
+        .token.tag .token.punctuation,
+        .token.delimiter.important,
+        .token.selector .parent {
+            color: #4dd0e1;
+        }
+
+        .token.attr-name,
+        .token.boolean,
+        .token.boolean.important,
+        .token.number,
+        .token.constant,
+        .token.selector .token.attribute {
+            color: #ffb74d;
+        }
+
+        .token.class-name,
+        .token.key,
+        .token.parameter,
+        .token.property,
+        .token.property-access,
+        .token.variable {
+            color: #81c784;
+        }
+
+        .token.attr-value,
+        .token.inserted,
+        .token.color,
+        .token.selector .token.value,
+        .token.string,
+        .token.string .token.url-link {
+            color: #a5d6a7;
+        }
+
+        .token.builtin,
+        .token.keyword-array,
+        .token.package,
+        .token.regex {
+            color: #ce93d8;
+        }
+
+        .token.function,
+        .token.selector .token.class,
+        .token.selector .token.id {
+            color: #f48fb1;
+        }
+
+        .token.atrule .token.rule,
+        .token.combinator,
+        .token.keyword,
+        .token.operator,
+        .token.pseudo-class,
+        .token.pseudo-element,
+        .token.selector,
+        .token.unit {
+            color: #ffcc02;
+        }
+
+        .token.deleted,
+        .token.important {
+            color: #f48fb1;
+        }
+
+        .token.keyword-this,
+        .token.this {
+            color: #81c784;
+        }
+    }
+
+    // Dark mode rule field improvements
+    .rule-field {
+        .txt-hint {
+            color: #c0c6cc !important;
+        }
+
+        .lock-toggle {
+            background: rgba(90, 90, 100, 0.15) !important;
+            color: var(--txtPrimaryColor);
+
+            &:hover,
+            &:focus-visible {
+                background: rgba(90, 90, 100, 0.25) !important;
+            }
+        }
+
+        .unlock-overlay {
+            border-color: var(--baseAlt2Color);
+            background: rgba(42, 42, 52, 0.85);
+
+            &:hover,
+            &:focus-visible {
+                border-color: var(--baseAlt3Color);
+            }
+        }
+    }
+
+    // Dark mode index modal improvements
+    .overlay-panel {
+        .label.link-primary {
+            color: var(--primaryColor) !important;
+
+            &.label-info {
+                background: var(--infoAltColor);
+                color: var(--txtPrimaryColor) !important;
+            }
+
+            &:hover,
+            &:focus-visible {
+                opacity: 0.9;
+            }
+        }
+
+        .txt-hint {
+            color: #b0b6bc;
+        }
+    }
+
+    // Code editor dark mode improvements
+    .code-editor {
+        background: var(--baseAlt1Color);
+
+        .cm-editor {
+            color: var(--txtPrimaryColor);
+
+            .cm-content {
+                color: var(--txtPrimaryColor);
+            }
+
+            .cm-placeholder {
+                color: var(--txtHintColor) !important;
+            }
+
+            .cm-focused {
+                outline: none;
+            }
+        }
+    }
+
+    // TinyMCE dark mode styling
+    .tinymce-wrapper {
+        .form-field label ~ & {
+            &:before {
+                background: var(--baseAlt1Color) !important;
+            }
+        }
+    }
+
+    // TinyMCE global dark mode overrides
+    .tox {
+        &.tox-tinymce {
+            background: var(--baseAlt1Color) !important;
+            border: 1px solid var(--baseAlt2Color) !important;
+        }
+
+        .tox-toolbar,
+        .tox-toolbar__primary,
+        .tox-toolbar__overflow {
+            background: var(--baseAlt2Color) !important;
+            border-bottom: 1px solid var(--baseAlt3Color) !important;
+        }
+
+        .tox-edit-area {
+            background: var(--baseAlt1Color) !important;
+        }
+
+        .tox-edit-area iframe {
+            background: var(--baseAlt1Color) !important;
+        }
+
+        .tox-tbtn {
+            color: var(--txtPrimaryColor) !important;
+
+            &:hover,
+            &:focus {
+                background: var(--baseAlt3Color) !important;
+                color: var(--txtPrimaryColor) !important;
+            }
+
+            &.tox-tbtn--enabled {
+                background: var(--baseAlt3Color) !important;
+                color: var(--txtPrimaryColor) !important;
+            }
+        }
+
+        .tox-button,
+        .tox-button--secondary {
+            background: var(--baseAlt2Color) !important;
+            color: var(--txtPrimaryColor) !important;
+            border: 1px solid var(--baseAlt3Color) !important;
+
+            &:hover,
+            &:focus {
+                background: var(--baseAlt3Color) !important;
+            }
+        }
+
+        .tox-dialog {
+            background: var(--baseColor) !important;
+            border: 1px solid var(--baseAlt2Color) !important;
+        }
+
+        .tox-dialog__header {
+            background: var(--baseAlt1Color) !important;
+            border-bottom: 1px solid var(--baseAlt2Color) !important;
+            color: var(--txtPrimaryColor) !important;
+        }
+
+        .tox-dialog__body {
+            background: var(--baseColor) !important;
+            color: var(--txtPrimaryColor) !important;
+        }
+
+        .tox-dialog__footer {
+            background: var(--baseAlt1Color) !important;
+            border-top: 1px solid var(--baseAlt2Color) !important;
+        }
+
+        .tox-textfield,
+        .tox-textarea,
+        .tox-listbox--select {
+            background: var(--baseAlt1Color) !important;
+            color: var(--txtPrimaryColor) !important;
+            border: 1px solid var(--baseAlt3Color) !important;
+
+            &:focus {
+                border-color: var(--primaryColor) !important;
+            }
+        }
+
+        .tox-menu,
+        .tox-collection {
+            background: var(--baseColor) !important;
+            border: 1px solid var(--baseAlt2Color) !important;
+        }
+
+        .tox-collection__item {
+            color: var(--txtPrimaryColor) !important;
+
+            &:hover,
+            &.tox-collection__item--active {
+                background: var(--baseAlt1Color) !important;
+            }
+        }
+
+        .tox-statusbar {
+            background: var(--baseAlt2Color) !important;
+            border-top: 1px solid var(--baseAlt3Color) !important;
+            color: var(--txtHintColor) !important;
+        }
+
+        // Content area styling (iframe content)
+        .tox-edit-area__iframe {
+            background: var(--baseAlt1Color) !important;
+        }
+    }
+
+    // TinyMCE iframe content styling (injected into iframe)
+    body.tox-content-body {
+        background: var(--baseAlt1Color) !important;
+        color: var(--txtPrimaryColor) !important;
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            color: var(--txtPrimaryColor) !important;
+        }
+
+        p,
+        div,
+        span {
+            color: var(--txtPrimaryColor) !important;
+        }
+
+        a {
+            color: var(--primaryColor) !important;
+        }
+
+        blockquote {
+            border-left-color: var(--baseAlt3Color) !important;
+            background: var(--baseAlt2Color) !important;
+        }
+
+        code {
+            background: var(--baseAlt2Color) !important;
+            color: var(--txtPrimaryColor) !important;
+        }
+
+        pre {
+            background: var(--baseAlt2Color) !important;
+            color: var(--txtPrimaryColor) !important;
+            border: 1px solid var(--baseAlt3Color) !important;
+        }
+
+        table {
+            border-color: var(--baseAlt3Color) !important;
+
+            th,
+            td {
+                border-color: var(--baseAlt3Color) !important;
+                color: var(--txtPrimaryColor) !important;
+            }
+
+            th {
+                background: var(--baseAlt2Color) !important;
+            }
+        }
+    }
+}

--- a/ui/src/scss/main.scss
+++ b/ui/src/scss/main.scss
@@ -47,3 +47,5 @@
 @import 'collections_export';
 
 @import 'rate_limit';
+
+@import 'dark';

--- a/ui/src/stores/darkMode.ts
+++ b/ui/src/stores/darkMode.ts
@@ -1,0 +1,30 @@
+import { writable } from "svelte/store";
+
+const createDarkModeStore = () => {
+    const defaultValue = false;
+    const initialValue = typeof window !== "undefined" ? localStorage.getItem("darkMode") === "true" : defaultValue;
+    
+    const { subscribe, set, update } = writable(initialValue);
+
+    return {
+        subscribe,
+        set: (value) => {
+            if (typeof window !== "undefined") {
+                localStorage.setItem("darkMode", value.toString());
+                document.documentElement.setAttribute("data-theme", value ? "dark" : "light");
+            }
+            set(value);
+        },
+        update,
+        toggle: () => update(n => {
+            const newValue = !n;
+            if (typeof window !== "undefined") {
+                localStorage.setItem("darkMode", newValue.toString());
+                document.documentElement.setAttribute("data-theme", newValue ? "dark" : "light");
+            }
+            return newValue;
+        })
+    };
+};
+
+export const darkMode = createDarkModeStore();


### PR DESCRIPTION
- Introduced `darkMode` store to manage the theme state.
- Implemented `DarkModeToggle` component for switching between light and dark themes.
- Updated `App.svelte` to initialize and apply the selected theme on app load.
- Added SCSS overrides for dark mode styling.
- Integrated dark mode toggle option in the sidebar and user dropdown menu.

https://github.com/user-attachments/assets/33bd91bd-c824-4878-b226-16907388c6df
