### PR TITLE
Feature for Web UI: Enable seconds in datetime picker' default options

### DIFF
--- a/ui/src/utils/CommonHelper.js
+++ b/ui/src/utils/CommonHelper.js
@@ -1422,6 +1422,7 @@ export default class CommonHelper {
             disableMobile: true,
             allowInput: true,
             enableTime: true,
+            enableSeconds: true,
             time_24hr: true,
             locale: {
                 firstDayOfWeek: 1,


### PR DESCRIPTION
Thanks for the great work on pocketbase!

## TL;DR

Add `enableSeconds: true` to the `defaultFlatpickrOptions` in `ui/src/utils/CommonHelper.js` to be able to set seconds through the `Datetime` picker in the web UI.

## Current State

When updating a record in the web UI, I noticed that the date & time picker component (`Flatpickr`) offers to set the date, the hour and the minute, but not the second -- despite seconds being stored in the `Datetime` field type. The following screenshot illustrates this.
<img width="312" height="446" alt="Screenshot 2025-09-04 155237" src="https://github.com/user-attachments/assets/89333083-9c50-46ea-a207-d47278cfa091" />

This leads to **an inconvenience and subtly unexpected behavior**:

1. Inconvenience: To set the seconds in a record's datetime field through the web UI, one *has to* enter the datetime in the text box above the date picker. Maybe it's no big deal for most users, but convenience would justify offering a picker in the first place. Without the seconds, the feature seems incomplete.
2. Unexpected behavior: When the picker closes, e.g. upon leaving the datetime field's focus, the currently selected datetime from the picker is written into the record. This overwrites the seconds to a value of zero, regardless of what was entered beforehand. I could not find a way to click through the UI in a way that the seconds remain what I typed. The way the seconds are being lost is not obvious to the user if they don't check the record after editing the datetime.
3. Inconsistent UI state: A change in the seconds by editing the string atop is not reflected in changes in the picker component while the picker and the datetime string seem to be nicely in sync otherwise. This is shown in the following screenshot. Ultimately, I think that one of the greatest strengths of the web UI is that its capabilities are pretty much entirely consistent with what pocketbase can represent. This picker is the only exception I could find so far.
<img width="300" height="438" alt="Screenshot 2025-09-04 160051" src="https://github.com/user-attachments/assets/3c644cbf-fd3b-462b-884e-f03142a12971" />

## How to reproduce

- spin up a fresh instance of pocketbase
- visit the web UI in a browser
- create the superuser account (or log in)
- create a collection
- add a `Datetime` type field to the collection
- create a record in that collection
- pick some date and time using the picker UI component
- try to change the seconds in the timestamp
- click basically anywhere to close the picker
- notice how the seconds were reset to "00"

## Proposed Solution

As seconds are representable by pockebase's `Datetime` field type, I propose to offer setting the seconds through the same picker already in use.

For the `Flatpickr` component used here, I found that several options are provided to configure the features and appearance of the picker. Setting the `enableSeconds` option to `true` seems to provide a picker for the seconds, similar to hours and minutes. Docs: https://flatpickr.js.org/options/

In `pocketbase`, the picker seems to use a set of default options defined in `ui/src/utils/CommonHelper.js` with `defaultFlatpickrOptions`. Adding the mentioned option would result in something like this:
```js
    static defaultFlatpickrOptions() {
        return {
            dateFormat: "Y-m-d H:i:S",
            disableMobile: true,
            allowInput: true,
            enableTime: true,
            enableSeconds: true,        // new option proposed in this PR
            time_24hr: true,
            locale: {
                firstDayOfWeek: 1,
            },
        }
    }
```

## Result

After building the project locally, the picker component now offers to set the seconds as well, as visible in the following screenshot. The expected behavior (setting seconds in the field's entry correctly after closing the picker) seems to be present.
<img width="302" height="433" alt="image" src="https://github.com/user-attachments/assets/98af2461-46a6-48df-ba80-78611e8f6712" />

**Environment:**
- `GOOS=linux`
- `GOARCH=amd64`
- Go version: 1.25.1

## Further Considerations

- **Who needs seconds?** In our project, we do need the seconds as there may be records with timestamps identical to the minute, which is inaccurate for our purposes. Of course, we could set the seconds through the API calls, but the web UI has proven to be extremely useful for prototyping except for this little nitpick.
- **Why not go further and add milliseconds etc?** Well, this would imply additional design decisions for the `Datetime` field type as it does not represent smaller time units at the moment. My guess is that this would be beyond the scope of pocketbase, given its intended use.
- **How much testing did you do?** Not too much, honestly. I branched off the official `master` branch, changed the one line mentioned above, and the change seems to work. Please feel free to try the change on various devices, screen sizes etc.