### PR TITLE
Add configurable max render length for Text columns in Admin UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 
 .DS_Store
 
+/ui/dist/
+CLAUDE.md
+
 # goreleaser builds folder
 /.builds/
 

--- a/core/field_text.go
+++ b/core/field_text.go
@@ -91,6 +91,11 @@ type TextField struct {
 	//
 	// A single collection can have only 1 field marked as primary key.
 	PrimaryKey bool `form:"primaryKey" json:"primaryKey"`
+
+	// MaxRenderLength specifies the maximum characters to display in the dashboard for string values.
+	//
+	// If zero value, defaults to 150 characters.
+	MaxRenderLength int `form:"maxRenderLength" json:"maxRenderLength"`
 }
 
 // Type implements [Field.Type] interface method.
@@ -265,6 +270,7 @@ func (f *TextField) ValidateSettings(ctx context.Context, app App, collection *C
 		validation.Field(&f.Hidden, validation.When(f.PrimaryKey, validation.Empty)),
 		validation.Field(&f.Required, validation.When(f.PrimaryKey, validation.Required)),
 		validation.Field(&f.AutogeneratePattern, validation.By(validators.IsRegex), validation.By(f.checkAutogeneratePattern)),
+		validation.Field(&f.MaxRenderLength, validation.Min(0), validation.Max(maxSafeJSONInt)),
 	)
 }
 

--- a/ui/src/components/collections/schema/SchemaFieldText.svelte
+++ b/ui/src/components/collections/schema/SchemaFieldText.svelte
@@ -104,8 +104,7 @@
                         min="0"
                         max={Number.MAX_SAFE_INTEGER}
                         placeholder="Default to 150 characters"
-                        value={field.maxRenderLength || ""}
-                        on:input={(e) => (field.maxRenderLength = parseInt(e.target.value, 10))}
+                        bind:value={field.maxRenderLength}
                     />
                 </Field>
             </div>

--- a/ui/src/components/collections/schema/SchemaFieldText.svelte
+++ b/ui/src/components/collections/schema/SchemaFieldText.svelte
@@ -87,6 +87,28 @@
                     </div>
                 </Field>
             </div>
+
+            <div class="col-sm-6">
+                <Field class="form-field" name="fields.{key}.maxRenderLength" let:uniqueId>
+                    <label for={uniqueId}>
+                        <span class="txt">Max render characters</span>
+                        <i
+                            class="ri-information-line link-hint"
+                            use:tooltip={"Maximum characters to display in the dashboard table. Clear or set to 0 for default (150 characters)."}
+                        />
+                    </label>
+                    <input
+                        type="number"
+                        id={uniqueId}
+                        step="1"
+                        min="0"
+                        max={Number.MAX_SAFE_INTEGER}
+                        placeholder="Default to 150 characters"
+                        value={field.maxRenderLength || ""}
+                        on:input={(e) => (field.maxRenderLength = parseInt(e.target.value, 10))}
+                    />
+                </Field>
+            </div>
         </div>
     </svelte:fragment>
 </SchemaField>

--- a/ui/src/components/records/RecordFieldValue.svelte
+++ b/ui/src/components/records/RecordFieldValue.svelte
@@ -14,6 +14,7 @@
     export let short = false;
 
     $: rawValue = record?.[field.name];
+    $: maxTruncateLength = field.type === "text" && field.maxRenderLength > 0 ? field.maxRenderLength : 150;
 </script>
 
 {#if field.primaryKey}
@@ -124,11 +125,11 @@
 {:else if field.type === "geoPoint"}
     <div class="label"><GeoPointValue value={rawValue} /></div>
 {:else if short}
-    <span class="txt txt-ellipsis" title={CommonHelper.truncate(rawValue)}>
-        {CommonHelper.truncate(rawValue)}
+    <span class="txt txt-ellipsis" title={CommonHelper.truncate(rawValue, maxTruncateLength)}>
+        {CommonHelper.truncate(rawValue, maxTruncateLength)}
     </span>
 {:else}
-    <div class="block txt-break fallback-block">{rawValue}</div>
+    <div class="block txt-break fallback-block">{CommonHelper.truncate(rawValue, maxTruncateLength, true)}</div>
 {/if}
 
 <style>

--- a/ui/src/components/records/RecordFieldValue.svelte
+++ b/ui/src/components/records/RecordFieldValue.svelte
@@ -15,6 +15,20 @@
 
     $: rawValue = record?.[field.name];
     $: maxTruncateLength = field.type === "text" && field.maxRenderLength > 0 ? field.maxRenderLength : 150;
+    $: shouldWrapText = field.type === "text" && field.maxRenderLength > 0;
+
+    // Debug: Log field info when it's a text field
+    $: if (field.type === "text") {
+        console.log("Text field debug:", {
+            fieldName: field.name,
+            fieldType: field.type,
+            maxRenderLength: field.maxRenderLength,
+            shouldWrapText: shouldWrapText,
+            maxTruncateLength: maxTruncateLength,
+            short: short,
+            rawValue: rawValue
+        });
+    }
 </script>
 
 {#if field.primaryKey}
@@ -124,6 +138,10 @@
     </div>
 {:else if field.type === "geoPoint"}
     <div class="label"><GeoPointValue value={rawValue} /></div>
+{:else if shouldWrapText}
+    <div class="block txt-break text-wrap-block">
+        {rawValue.length > maxTruncateLength ? rawValue.substring(0, maxTruncateLength) + "..." : rawValue}
+    </div>
 {:else if short}
     <span class="txt txt-ellipsis" title={CommonHelper.truncate(rawValue, maxTruncateLength)}>
         {CommonHelper.truncate(rawValue, maxTruncateLength)}
@@ -136,5 +154,12 @@
     .fallback-block {
         max-height: 100px;
         overflow: auto;
+    }
+
+    .text-wrap-block {
+        word-wrap: break-word;
+        word-break: break-word;
+        white-space: pre-wrap;
+        line-height: 1.5;
     }
 </style>


### PR DESCRIPTION
This PR adds an optional "Max render length" setting when creating Text columns, allowing users to control how many characters are displayed before truncation in the webadmin table view.

Changes:
- New optional text field in column configuration (defaults to 150 chars if empty/zero)
- Text now wraps within the specified length before applying ellipsis
- Previously: no wrapping, ellipsis at column width
- Now: wrapping enabled, ellipsis at configured character count

Context:
I understand this is primarily a webadmin UI enhancement without direct API benefits, so I completely understand if this doesn't align with the project's direction. However, it solves a specific need in my PocketBase implementation, and I wanted to contribute it back in case others find it useful.

Happy to make any adjustments or close this if it's not a good fit for the core project.