### PR TITLE
Exclude the lost+found folder from backups

### DIFF
--- a/core/base.go
+++ b/core/base.go
@@ -40,6 +40,7 @@ const (
 	LocalBackupsDirName       string = "backups"
 	LocalTempDirName          string = ".pb_temp_to_delete" // temp pb_data sub directory that will be deleted on each app.Bootstrap()
 	LocalAutocertCacheDirName string = ".autocert_cache"
+	LocalLostFoundDirName     string = "lost+found"
 )
 
 // FilesManager defines an interface with common methods that files manager models should implement.

--- a/core/base_backup.go
+++ b/core/base_backup.go
@@ -54,7 +54,7 @@ func (app *BaseApp) CreateBackup(ctx context.Context, name string) error {
 	event.Context = ctx
 	event.Name = name
 	// default root dir entries to exclude from the backup generation
-	event.Exclude = []string{LocalBackupsDirName, LocalTempDirName, LocalAutocertCacheDirName}
+	event.Exclude = []string{LocalBackupsDirName, LocalTempDirName, LocalAutocertCacheDirName, LocalLostFoundDirName}
 
 	return app.OnBackupCreate().Trigger(event, func(e *BackupEvent) error {
 		// generate a default name if missing
@@ -159,7 +159,7 @@ func (app *BaseApp) RestoreBackup(ctx context.Context, name string) error {
 	event.Context = ctx
 	event.Name = name
 	// default root dir entries to exclude from the backup restore
-	event.Exclude = []string{LocalBackupsDirName, LocalTempDirName, LocalAutocertCacheDirName}
+	event.Exclude = []string{LocalBackupsDirName, LocalTempDirName, LocalAutocertCacheDirName, LocalLostFoundDirName}
 
 	return app.OnBackupRestore().Trigger(event, func(e *BackupEvent) error {
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
Hello,

When the pb_data folder is mounted from another filesystem, it will contain a "lost+found" folder which is accessible only to root.
If pocketbase is running as a non-root user, the backup process fails because this folder can't be read.

I have added "lost+found" to the list of excluded folders in the backup logic.