### PR TITLE
Fix incomplete multipart uploads when MaxConcurrency is 1

### DIFF
--- a/tools/filesystem/internal/s3blob/s3/uploader.go
+++ b/tools/filesystem/internal/s3blob/s3/uploader.go
@@ -353,6 +353,11 @@ func (u *Uploader) multipartUpload(ctx context.Context, initPart []byte, optReqF
 		})
 	}
 
+	// Ensure that the totalParallel is at least 1
+	if totalParallel < 1 {
+		totalParallel = 1
+	}
+
 	for i := 0; i < totalParallel; i++ {
 		g.Go(func() error {
 			for {


### PR DESCRIPTION
When `MaxConcurrency` is set to 1 and a multipart upload is initiated with an `initPart`, the code decrements `totalParallel` from 1 to 0, resulting in zero worker goroutines being started for the remaining file parts. This causes only the first part to be uploaded while the rest of the file is silently skipped.

This fix ensures at least one worker goroutine is always started to process the remaining parts, regardless of the `MaxConcurrency` value.

Fixes issue where files larger than `MinPartSize` would be incompletely uploaded when `MaxConcurrency=1`.