### PR TITLE
fixed GetInt handling of []byte

### DIFF
--- a/core/record_model.go
+++ b/core/record_model.go
@@ -956,7 +956,7 @@ func (m *Record) GetString(key string) string {
 
 // GetInt returns the data value for "key" as an int.
 func (m *Record) GetInt(key string) int {
-	return cast.ToInt(m.Get(key))
+	return cast.ToInt(cast.ToString(m.Get(key)))
 }
 
 // GetFloat returns the data value for "key" as a float64.


### PR DESCRIPTION
The [spf13/cast](https://github.com/spf13/cast) package's `ToInt` does not handle `[]byte` inputs, it only supports direct conversions from types like `int`, `float64`, `string` (valid integer representations), `bool`, etc. Unhandled types default to a zero value, so if `m.Get(key)` returns a byte slice (e.g. `types.JSONRaw`), the return value will always be 0.

The `ToString` function explicitly supports converting `[]byte` to a `string` (https://github.com/spf13/cast?tab=readme-ov-file#example-tostring). By running it first, something like `[]byte("123")` becomes `"123"` and then can be converted to `123`.

