### PR TITLE
Replace PseudorandomStringWithAlphabet to use math/rand/v2

### DIFF
--- a/tools/security/random.go
+++ b/tools/security/random.go
@@ -3,7 +3,7 @@ package security
 import (
 	cryptoRand "crypto/rand"
 	"math/big"
-	mathRand "math/rand" // @todo replace with rand/v2?
+	mathRand "math/rand/v2"
 )
 
 const defaultRandomAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
@@ -52,7 +52,7 @@ func PseudorandomStringWithAlphabet(length int, alphabet string) string {
 	max := len(alphabet)
 
 	for i := range b {
-		b[i] = alphabet[mathRand.Intn(max)]
+		b[i] = alphabet[mathRand.IntN(max)]
 	}
 
 	return string(b)


### PR DESCRIPTION
Just wanted to clean up a todo and updated the math/rand to math/rand/v2. Simple change and all tests seem to still pass.

David Corvaglia