### PR TITLE
Fix deadlock bug when triggering a termination

### DIFF
--- a/core/base.go
+++ b/core/base.go
@@ -1408,7 +1408,7 @@ func getLoggerMinLevel(app App) slog.Level {
 func (app *BaseApp) initLogger() error {
 	duration := 3 * time.Second
 	ticker := time.NewTicker(duration)
-	done := make(chan bool)
+	done := make(chan bool, 1)
 
 	handler := logger.NewBatchHandler(logger.BatchOptions{
 		Level:     getLoggerMinLevel(app),
@@ -1479,7 +1479,10 @@ func (app *BaseApp) initLogger() error {
 
 			ticker.Stop()
 
-			done <- true
+			select {
+			case done <- true:
+			default:
+			}
 
 			return e.Next()
 		},


### PR DESCRIPTION
Hey,

I'm pretty sure I found a deadlock bug when triggering a termination.

## Context

I wanted a graceful shutdown option for an app I'm working on.
Thats why I took a look how you implemented it.

PocketBase uses an interrupt signal (`signal.Notify(sigch, os.Interrupt, syscall.SIGTERM)`) which triggers the termination event through the `done` channel (from `/pocketbase.go`):

```go
done := make(chan bool, 1)

// listen for interrupt signal to gracefully shutdown the application
go func() {
    sigch := make(chan os.Signal, 1)
    signal.Notify(sigch, os.Interrupt, syscall.SIGTERM)
    <-sigch

    done <- true
}()

// execute the root command
go func() {
    // note: leave to the commands to decide whether to print their error
    pb.RootCmd.Execute()

    done <- true
}()

<-done

// trigger cleanups
event := new(core.TerminateEvent)
event.App = pb
return pb.OnTerminate().Trigger(event, func(e *core.TerminateEvent) error {
    return e.App.ResetBootstrapState()
})
```

So I copied the code for triggering a termination event into my project (`app.OnTerminate().Trigger(&core.TerminateEvent{App: app})`).

But that triggered a deadlock.

## How this can happen

When the application runs normally and the termination event fires, the registered handlers are executed and the web server is shut down as intended.

In the snippet above, `pb.RootCmd.Execute()` starts the web server, so once the server shuts down the function returns, writes `true` into `done`, and PocketBase - still waiting on `<-done` - fires another termination event.

**Up to this point everything is fine**: the termination handlers run a second time, which should be harmless for all handlers except one.

## The problematic handler

The handler in question is (`__pbAppLoggerOnTerminate__`) in `/core/base.go`:

```go
app.OnTerminate().Bind(&hook.Handler[*TerminateEvent]{
    Id: "__pbAppLoggerOnTerminate__",
    Func: func(e *TerminateEvent) error {
        handler.WriteAll(context.Background())

        ticker.Stop()

        done <- true

        return e.Next()
    },
    Priority: -999,
})
```

The `done` channel is unbuffered, and the real issue is `done <- true`. Adding a buffer helps, but if the handler runs `x` times you’d need a buffer of size `x - 1`, which is arbitrary.

That's why I replaced the blocking send with a `select`:

```go
select {
case done <- true:
default:
}
```

This way, if nobody is listening or the channel is already full, the send doesn’t block. Without this, the handler never returns, so the routine that triggered it stalls forever.

This simple change fixes the problem and allows triggering the termination event outside PocketBase as intended.

I also made the `done` channel buffered because, even though it shouldn’t happen, the write can theoretically occur before the listener starts. An unbuffered channel would skip the send if no listener existed yet; if the listener starts afterwards, the signal would be lost.

---

Thank you very much for this great project. I really love it! :heart: 
