### PR TITLE
Fix: autocomplete for modifiers breaks down at the ":" char

### DIFF
--- a/ui/src/components/base/FilterAutocompleteInput.svelte
+++ b/ui/src/components/base/FilterAutocompleteInput.svelte
@@ -244,7 +244,7 @@
 
     // Returns object with all the completions matching the context.
     function completions(context) {
-        let word = context.matchBefore(/[\'\"\@\w\.]*/);
+        let word = context.matchBefore(/[\'\"\@\w\.:]*/);
         if (word && word.from == word.to && !context.explicit) {
             return null;
         }


### PR DESCRIPTION
When writing rules/filters, the autocomplete display correctly the possible modifier variants. But when the ":" character is typed, the autocomplete stops. It resumes only when two characters of the possible modifier(s) are typed.

![Image](https://github.com/user-attachments/assets/04433432-aaa9-47a2-b5ae-7a0638e68933)

I think that's due to the fact ":" is not part of the word regex in FilterAutocompleteInput.svelte, so the modifier is considered as a new word.
   https://github.com/pocketbase/pocketbase/blob/90d896e1cc49e3535dad95718dada3f7efcef4ca/ui/src/components/base/FilterAutocompleteInput.svelte#L247

I updated the regex locally to `let word = context.matchBefore(/[\'\"\@\w\.:]*/);` and it seems to be working fine ⬇️ 

<img width="439" height="122" alt="Image" src="https://github.com/user-attachments/assets/0b04f493-4b69-4f54-b210-f2225be98a6b" />

I'm not seeing UI tests, so I'm worried that the fix itself could have some side effects.
I can transform this PR into an issue if you prefer to take the time to look into that yourself.