### PR TITLE
Add PocketBase.Blazor SDK client to official SDK list

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The easiest way to interact with the PocketBase Web APIs is to use one of the of
 
 - **JavaScript - [pocketbase/js-sdk](https://github.com/pocketbase/js-sdk)** (_Browser, Node.js, React Native_)
 - **Dart - [pocketbase/dart-sdk](https://github.com/pocketbase/dart-sdk)** (_Web, Mobile, Desktop, CLI_)
+- **C#/Blazor** - [PocketBase.Blazor](https://github.com/celsojr/PocketBase.Blazor) (_Blazor WebAssembly, .NET 8_)
 
 You could also check the recommendations in https://pocketbase.io/docs/how-to-use/.
 


### PR DESCRIPTION
This PR adds the C#/Blazor SDK client to the official list of PocketBase API SDKs.

**PocketBase.Blazor** is a lightweight, DI-friendly wrapper for Blazor WebAssembly and .NET 8 projects. It provides:

- HttpClient-based CRUD operations for collections and records
- Simple configuration via PocketBaseOptions
- Built-in JSON serialization options compatible with Blazor
- A sample Blazor WASM app for reference
- Unit test skeleton for client-side testing

Link: [https://github.com/celsojr/PocketBase.Blazor](https://github.com/celsojr/PocketBase.Blazor)

This addition helps .NET and Blazor developers easily discover and integrate PocketBase into their applications.
