### PR TITLE
added Figma OAuth2 provider

### DIFF
--- a/tools/auth/auth_test.go
+++ b/tools/auth/auth_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestProvidersCount(t *testing.T) {
-	expected := 32
+	expected := 33
 
 	if total := len(auth.Providers); total != expected {
 		t.Fatalf("Expected %d providers, got %d", expected, total)
@@ -313,5 +313,14 @@ func TestNewProviderByName(t *testing.T) {
 	}
 	if _, ok := p.(*auth.Lark); !ok {
 		t.Error("Expected to be instance of *auth.Lark")
+	}
+
+	// figma
+	p, err = auth.NewProviderByName(auth.NameFigma)
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+	if _, ok := p.(*auth.Figma); !ok {
+		t.Error("Expected to be instance of *auth.Figma")
 	}
 }

--- a/tools/auth/figma.go
+++ b/tools/auth/figma.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/tools/types"
+	"golang.org/x/oauth2"
+)
+
+func init() {
+	Providers[NameFigma] = wrapFactory(NewFigmaProvider)
+}
+
+var _ Provider = (*Figma)(nil)
+
+// NameFigma is the unique name of the Figma provider.
+const NameFigma string = "figma"
+
+// Figma allows authentication via Figma OAuth2.
+type Figma struct {
+	BaseProvider
+}
+
+// NewFigmaProvider creates a new Figma provider instance with some defaults.
+func NewFigmaProvider() *Figma {
+	// https://www.figma.com/developers/api#oauth2
+	// https://developers.figma.com/docs/rest-api/authentication/
+	return &Figma{BaseProvider{
+		ctx:         context.Background(),
+		displayName: "Figma",
+		pkce:        true,
+		scopes:      []string{"current_user:read"},
+		authURL:     "https://www.figma.com/oauth",
+		tokenURL:    "https://api.figma.com/v1/oauth/token",
+		userInfoURL: "https://api.figma.com/v1/me",
+	}}
+}
+
+// FetchAuthUser returns an AuthUser instance based on Figma's user api.
+//
+// API reference: https://developers.figma.com/docs/rest-api/users-endpoints/
+func (p *Figma) FetchAuthUser(token *oauth2.Token) (*AuthUser, error) {
+	data, err := p.FetchRawUserInfo(token)
+	if err != nil {
+		return nil, err
+	}
+
+	rawUser := map[string]any{}
+	if err := json.Unmarshal(data, &rawUser); err != nil {
+		return nil, err
+	}
+
+	extracted := struct {
+		Id       string `json:"id"`
+		Handle   string `json:"handle"`
+		Email    string `json:"email"`
+		ImageURL string `json:"img_url"`
+	}{}
+	if err := json.Unmarshal(data, &extracted); err != nil {
+		return nil, err
+	}
+
+	user := &AuthUser{
+		Id:           extracted.Id,
+		Name:         extracted.Handle,
+		Email:        extracted.Email,
+		AvatarURL:    extracted.ImageURL,
+		RawUser:      rawUser,
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+	}
+
+	user.Expiry, _ = types.ParseDateTime(token.Expiry)
+
+	return user, nil
+}


### PR DESCRIPTION
Adds Figma as an OAuth2 authentication provider.

## Details

- **Auth URL**: `https://www.figma.com/oauth`
- **Token URL**: `https://api.figma.com/v1/oauth/token`
- **User Info URL**: `https://api.figma.com/v1/me`
- **Scope**: `current_user:read`
- **PKCE**: Enabled

## User fields mapped

| Figma field | AuthUser field |
|-------------|----------------|
| `id` | `Id` |
| `handle` | `Name` |
| `email` | `Email` |
| `img_url` | `AvatarURL` |

## References

- [Figma OAuth2 docs](https://developers.figma.com/docs/rest-api/authentication/)
- [Figma User endpoint](https://developers.figma.com/docs/rest-api/users-endpoints/)