### PR TITLE
added Zoom OAuth2 provider

### DIFF
--- a/tools/auth/auth_test.go
+++ b/tools/auth/auth_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestProvidersCount(t *testing.T) {
-	expected := 32
+	expected := 33
 
 	if total := len(auth.Providers); total != expected {
 		t.Fatalf("Expected %d providers, got %d", expected, total)
@@ -313,5 +313,14 @@ func TestNewProviderByName(t *testing.T) {
 	}
 	if _, ok := p.(*auth.Lark); !ok {
 		t.Error("Expected to be instance of *auth.Lark")
+	}
+
+	// zoom
+	p, err = auth.NewProviderByName(auth.NameZoom)
+	if err != nil {
+		t.Errorf("Expected nil, got error %v", err)
+	}
+	if _, ok := p.(*auth.Zoom); !ok {
+		t.Error("Expected to be instance of *auth.Zoom")
 	}
 }

--- a/tools/auth/zoom.go
+++ b/tools/auth/zoom.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pocketbase/pocketbase/tools/types"
+	"golang.org/x/oauth2"
+)
+
+func init() {
+	Providers[NameZoom] = wrapFactory(NewZoomProvider)
+}
+
+var _ Provider = (*Zoom)(nil)
+
+// NameZoom is the unique name of the Zoom provider.
+const NameZoom string = "zoom"
+
+// Zoom allows authentication via Zoom OAuth2.
+type Zoom struct {
+	BaseProvider
+}
+
+// NewZoomProvider creates a new Zoom provider instance with some defaults.
+func NewZoomProvider() *Zoom {
+	// https://developers.zoom.us/docs/integrations/oauth/
+	return &Zoom{BaseProvider{
+		ctx:         context.Background(),
+		displayName: "Zoom",
+		pkce:        true,
+		scopes:      []string{"user:read:user"},
+		authURL:     "https://zoom.us/oauth/authorize",
+		tokenURL:    "https://zoom.us/oauth/token",
+		userInfoURL: "https://api.zoom.us/v2/users/me",
+	}}
+}
+
+// FetchAuthUser returns an AuthUser instance based on Zoom's user api.
+//
+// API reference: https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/user
+func (p *Zoom) FetchAuthUser(token *oauth2.Token) (*AuthUser, error) {
+	data, err := p.FetchRawUserInfo(token)
+	if err != nil {
+		return nil, err
+	}
+
+	rawUser := map[string]any{}
+	if err := json.Unmarshal(data, &rawUser); err != nil {
+		return nil, err
+	}
+
+	extracted := struct {
+		Id        string `json:"id"`
+		FirstName string `json:"first_name"`
+		LastName  string `json:"last_name"`
+		Email     string `json:"email"`
+		PicURL    string `json:"pic_url"`
+		Verified  int    `json:"verified"`
+	}{}
+	if err := json.Unmarshal(data, &extracted); err != nil {
+		return nil, err
+	}
+
+	user := &AuthUser{
+		Id:           extracted.Id,
+		Name:         extracted.FirstName + " " + extracted.LastName,
+		AvatarURL:    extracted.PicURL,
+		RawUser:      rawUser,
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+	}
+
+	user.Expiry, _ = types.ParseDateTime(token.Expiry)
+
+	if extracted.Verified == 1 {
+		user.Email = extracted.Email
+	}
+
+	return user, nil
+}


### PR DESCRIPTION
Adds Zoom as an OAuth2 authentication provider.

## Details

- **Auth URL**: `https://zoom.us/oauth/authorize`
- **Token URL**: `https://zoom.us/oauth/token`
- **User Info URL**: `https://api.zoom.us/v2/users/me`
- **Scope**: `user:read:user`
- **PKCE**: Enabled

## User fields mapped

| Zoom field | AuthUser field |
|------------|----------------|
| `id` | `Id` |
| `first_name` + `last_name` | `Name` |
| `email` | `Email` (only if `verified == 1`) |
| `pic_url` | `AvatarURL` |

## References

- [Zoom OAuth2 docs](https://developers.zoom.us/docs/integrations/oauth/)
- [Zoom User API](https://developers.zoom.us/docs/api/rest/reference/user/methods/#operation/user)