### PR TITLE
dockerized the project for ease of development and deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.dockerignore
+docker-compose.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:alpine3.23 AS builder
+
+WORKDIR /app
+COPY . .
+
+WORKDIR /app/examples/base
+RUN go build -o /build/pocketbase
+
+
+FROM alpine:3.23 AS runtime
+
+WORKDIR /app
+COPY --from=builder /build/pocketbase /bin/pocketbase
+ENTRYPOINT ["/bin/pocketbase"]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ windows amd64
 windows arm64
 ```
 
+### run the repo main.go example via docker
+
+To run and build the dockerize version, you can simply run `docker compose up -d`
+
+0. [Install Docker](https://docs.docker.com/engine/install/) (_if you haven't already_)
+1. Clone/download the repo
+2. Build it with `docker build -it pocketbase:latest .`
+3. Run it with `docker run -p 8090:8090 -it pocketbase:latest`
+
 ### Testing
 
 PocketBase comes with mixed bag of unit and integration tests.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  pocketbase:
+    build: .
+    ports:
+      - "8090:8090"
+    volumes:
+      - ./pb_data:/app/pb_data
+      - ./pb_public:/app/pb_public
+      - ./pb_hooks:/app/pb_hooks


### PR DESCRIPTION
now... I'm not sure if throwing dockerization into the mix is a good idea, since the project are currently still in its infancy, but  since backward compatibility is not guaranteed, i think this may help other to see if changing to the latest version would have minor or significant changes to their setup, atleast for static or js extend that is.

although with that being said... i  mainly want to use this as a quick and dirty way to quickly build out a prototype without cluttering my go pkg folder :grin: 