### PR TITLE
perf(security): upgrade to math/rand/v2

### DIFF
--- a/tools/security/random.go
+++ b/tools/security/random.go
@@ -3,7 +3,7 @@ package security
 import (
 	cryptoRand "crypto/rand"
 	"math/big"
-	mathRand "math/rand" // @todo replace with rand/v2?
+	mathRand "math/rand/v2"
 )
 
 const defaultRandomAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
@@ -52,7 +52,7 @@ func PseudorandomStringWithAlphabet(length int, alphabet string) string {
 	max := len(alphabet)
 
 	for i := range b {
-		b[i] = alphabet[mathRand.Intn(max)]
+		b[i] = alphabet[mathRand.IntN(max)]
 	}
 
 	return string(b)


### PR DESCRIPTION
The old `math/rand` uses a global lock on every call. Under concurrent load (which is pretty much every request since `PseudorandomString` is used for filter placeholders, hook IDs, query aliases, etc.), this becomes a bottleneck.

`math/rand/v2` uses per-goroutine state so there's no lock contention.

See: [Go 1.22 rand/v2 blog post](https://go.dev/blog/randv2) and [math/rand/v2 docs](https://pkg.go.dev/math/rand/v2)