### PR TITLE
fix: typos in comments

### DIFF
--- a/core/settings_model.go
+++ b/core/settings_model.go
@@ -423,7 +423,7 @@ type BatchConfig struct {
 	// MaxRequests is the maximum allowed batch request to execute.
 	MaxRequests int `form:"maxRequests" json:"maxRequests"`
 
-	// Timeout is the the max duration in seconds to wait before cancelling the batch transaction.
+	// Timeout is the max duration in seconds to wait before cancelling the batch transaction.
 	Timeout int64 `form:"timeout" json:"timeout"`
 
 	// MaxBodySize is the maximum allowed batch request body size in bytes.
@@ -449,7 +449,7 @@ type BackupsConfig struct {
 	// Leave it empty to disable the auto backups functionality.
 	Cron string `form:"cron" json:"cron"`
 
-	// CronMaxKeep is the the max number of cron generated backups to
+	// CronMaxKeep is the max number of cron generated backups to
 	// keep before removing older entries.
 	//
 	// This field works only when the cron config has valid cron expression.

--- a/tools/filesystem/internal/s3blob/s3blob.go
+++ b/tools/filesystem/internal/s3blob/s3blob.go
@@ -46,7 +46,7 @@ import (
 
 const defaultPageSize = 1000
 
-// New creates a new instance of the S3 driver backed by the the internal S3 client.
+// New creates a new instance of the S3 driver backed by the internal S3 client.
 func New(s3Client *s3.S3) (blob.Driver, error) {
 	if s3Client.Bucket == "" {
 		return nil, errors.New("s3blob.New: missing bucket name")


### PR DESCRIPTION
## Summary

Fix typos in comments:

- `tools/filesystem/internal/s3blob/s3blob.go`: `the the internal` → `the internal`
- `core/settings_model.go`: `the the max` → `the max` (2 occurrences)