### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,12 +16,12 @@ jobs:
         run: echo "flags=--snapshot" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.17.0
 


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/release.yaml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yaml`
