### PR TITLE
Fixed data races found on concurrency tests

### DIFF
--- a/tools/search/provider_test.go
+++ b/tools/search/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -741,6 +742,7 @@ type testTableStruct struct {
 
 type testDB struct {
 	*dbx.DB
+	m             sync.Mutex
 	CalledQueries []string
 }
 
@@ -765,6 +767,8 @@ func createTestDB() (*testDB, error) {
 	db.Insert("test", dbx.Params{"id": 1, "test1": 1, "test2": "test2.1"}).Execute()
 	db.Insert("test", dbx.Params{"id": 2, "test1": 2, "test2": "test2.2"}).Execute()
 	db.QueryLogFunc = func(ctx context.Context, t time.Duration, sql string, rows *sql.Rows, err error) {
+		db.m.Lock()
+		defer db.m.Unlock()
 		db.CalledQueries = append(db.CalledQueries, sql)
 	}
 

--- a/tools/subscriptions/client_test.go
+++ b/tools/subscriptions/client_test.go
@@ -3,6 +3,7 @@ package subscriptions_test
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -210,10 +211,13 @@ func TestDiscard(t *testing.T) {
 func TestSend(t *testing.T) {
 	c := subscriptions.NewDefaultClient()
 
+	var mx sync.Mutex
 	received := []string{}
 	go func() {
 		for m := range c.Channel() {
+			mx.Lock()
 			received = append(received, m.Name)
+			mx.Unlock()
 		}
 	}()
 
@@ -226,6 +230,8 @@ func TestSend(t *testing.T) {
 
 	expected := []string{"m1", "m2"}
 
+	mx.Lock()
+	defer mx.Unlock()
 	if len(received) != len(expected) {
 		t.Fatalf("Expected %d messages, got %d", len(expected), len(received))
 	}


### PR DESCRIPTION
Added mutexes for accessing expectations in tests.