### PR TITLE
feat: support constant array operands in API rules

### DIFF
--- a/core/record_field_resolver_test.go
+++ b/core/record_field_resolver_test.go
@@ -665,6 +665,20 @@ func TestRecordFieldResolverUpdateQuery(t *testing.T) {
 			false,
 			"SELECT DISTINCT `demo5`.* FROM `demo5` LEFT JOIN json_each(CASE WHEN iif(json_valid([[demo5.rel_many]]), json_type([[demo5.rel_many]])='array', FALSE) THEN [[demo5.rel_many]] ELSE json_array([[demo5.rel_many]]) END) `__je_demo5_rel_many` LEFT JOIN `demo4` `demo5_rel_many` ON [[demo5_rel_many.id]] = [[__je_demo5_rel_many.value]] WHERE (((strftime({:TEST},[[demo5_rel_many.created]]) = 1) AND (NOT EXISTS (SELECT 1 FROM (SELECT strftime({:TEST},[[__mm_demo5_rel_many.created]]) as [[multiMatchValue]] FROM `demo5` `__mm_demo5` LEFT JOIN json_each(CASE WHEN iif(json_valid([[__mm_demo5.rel_many]]), json_type([[__mm_demo5.rel_many]])='array', FALSE) THEN [[__mm_demo5.rel_many]] ELSE json_array([[__mm_demo5.rel_many]]) END) `__mm_demo5_rel_many_je` LEFT JOIN `demo4` `__mm_demo5_rel_many` ON [[__mm_demo5_rel_many.id]] = [[__mm_demo5_rel_many_je.value]] WHERE `__mm_demo5`.`id` = `demo5`.`id`) {{__smTEST}} WHERE NOT ([[__smTEST.multiMatchValue]] = 1)))))",
 		},
+		{
+			"auto-explode multi-value field (select_many with ?=)",
+			"demo1",
+			"select_many ?= array('a', 'b')",
+			false,
+			"SELECT DISTINCT `demo1`.* FROM `demo1` LEFT JOIN json_each(CASE WHEN iif(json_valid([[demo1.select_many]]), json_type([[demo1.select_many]])='array', FALSE) THEN [[demo1.select_many]] ELSE json_array([[demo1.select_many]]) END) `__je_demo1_select_many` WHERE COALESCE([[__je_demo1_select_many.value]], '') IN ({:TEST},{:TEST})",
+		},
+		{
+			"auto-explode multi-value field (select_many with ?!=)",
+			"demo1",
+			"select_many ?!= array('a', 'b')",
+			false,
+			"SELECT DISTINCT `demo1`.* FROM `demo1` LEFT JOIN json_each(CASE WHEN iif(json_valid([[demo1.select_many]]), json_type([[demo1.select_many]])='array', FALSE) THEN [[demo1.select_many]] ELSE json_array([[demo1.select_many]]) END) `__je_demo1_select_many` WHERE COALESCE([[__je_demo1_select_many.value]], '') NOT IN ({:TEST},{:TEST})",
+		},
 	}
 
 	for _, s := range scenarios {

--- a/tools/search/filter_test.go
+++ b/tools/search/filter_test.go
@@ -145,6 +145,18 @@ func TestFilterDataBuildExpr(t *testing.T) {
 			false,
 			"(6371 * acos(cos(radians({:TEST})) * cos(radians({:TEST})) * cos(radians({:TEST}) - radians({:TEST})) + sin(radians({:TEST})) * sin(radians({:TEST})))) < {:TEST}",
 		},
+		{
+			"array function with ?= (IN)",
+			"test1 ?= array('a', 'b')",
+			false,
+			"COALESCE([[test1]], '') IN ({:TEST},{:TEST})",
+		},
+		{
+			"array function with ?!= (NOT IN)",
+			"test2 ?!= array('x', 'y')",
+			false,
+			"COALESCE([[test2]], '') NOT IN ({:TEST},{:TEST})",
+		},
 	}
 
 	for _, s := range scenarios {

--- a/tools/search/simple_field_resolver.go
+++ b/tools/search/simple_field_resolver.go
@@ -42,6 +42,11 @@ type ResolverResult struct {
 	// AfterBuild is an optional function that will be called after building
 	// and combining the result of both resolved operands/sides in a single expression.
 	AfterBuild func(expr dbx.Expression) dbx.Expression
+
+	// IsInList when true indicates this operand represents a list of values for IN/NOT IN
+	// comparison (e.g. from the array() function). When used with = or != operators,
+	// the expression becomes "left IN (values)" or "left NOT IN (values)".
+	IsInList bool
 }
 
 // FieldResolver defines an interface for managing search fields.

--- a/ui/src/components/collections/docs/FilterSyntax.svelte
+++ b/ui/src/components/collections/docs/FilterSyntax.svelte
@@ -127,6 +127,13 @@
         To group and combine several expressions you could use brackets
         <code>(...)</code>, <code>&&</code> (AND) and <code>||</code> (OR) tokens.
     </p>
+    <p>
+        The <code>array(val1, val2, ...)</code> function creates a constant list for use with
+        <code class="filter-op">{"?="}</code> or <code class="filter-op">{"?!="}</code> operators.
+        Shorthand for checking if a field matches any value in a list, e.g.
+        <code>@request.auth.role ?= array("isSecretary", "isAccountant")</code> instead of
+        <code>@request.auth.role ?= "isSecretary" || @request.auth.role ?= "isAccountant"</code>.
+    </p>
 {/if}
 
 <style>


### PR DESCRIPTION
This PR adds support for constant array operands in PocketBase API rules.

It allows concise checks against multiple allowed values without repeating
OR conditions, for example:

@request.auth.role ?= array("isSecretary", "isAccountant")

Existing scalar `?=` behavior remains unchanged and backward compatible.
The array variant evaluates to true when there is at least one common value
between the field and the constant array.

Tests have been added to cover parsing and evaluation behavior.

Closes #6308