### PR TITLE
Fix case-sensitive bearer token prefix stripping

### DIFF
--- a/apis/middlewares.go
+++ b/apis/middlewares.go
@@ -210,9 +210,20 @@ func getAuthTokenFromRequest(e *core.RequestEvent) string {
 	if token != "" {
 		// the schema prefix is not required and it is only for
 		// compatibility with the defaults of some HTTP clients
-		token = strings.TrimPrefix(token, "Bearer ")
+		token = trimPrefixCI(strings.TrimSpace(token), "Bearer ")
 	}
 	return token
+}
+
+// trimPrefixCI is a case-insensitive version of strings.TrimPrefix.
+func trimPrefixCI(s string, prefix string) string {
+	if len(s) < len(prefix) {
+		return s
+	}
+	if strings.EqualFold(s[:len(prefix)], prefix) {
+		return s[len(prefix):]
+	}
+	return s
 }
 
 // wwwRedirect performs www->non-www redirect(s) if the request host

--- a/apis/middlewares_test.go
+++ b/apis/middlewares_test.go
@@ -192,6 +192,51 @@ func TestRequireAuth(t *testing.T) {
 			ExpectedContent: []string{"test123"},
 		},
 		{
+			Name:   "valid record auth token (prefixed)",
+			Method: http.MethodGet,
+			URL:    "/my/test",
+			Headers: map[string]string{
+				"Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjRxMXhsY2xtZmxva3UzMyIsInR5cGUiOiJhdXRoIiwiY29sbGVjdGlvbklkIjoiX3BiX3VzZXJzX2F1dGhfIiwiZXhwIjoyNTI0NjA0NDYxLCJyZWZyZXNoYWJsZSI6dHJ1ZX0.ZT3F0Z3iM-xbGgSG3LEKiEzHrPHr8t8IuHLZGGNuxLo",
+			},
+			BeforeTestFunc: func(t testing.TB, app *tests.TestApp, e *core.ServeEvent) {
+				e.Router.GET("/my/test", func(e *core.RequestEvent) error {
+					return e.String(200, "test123")
+				}).Bind(apis.RequireAuth())
+			},
+			ExpectedStatus:  200,
+			ExpectedContent: []string{"test123"},
+		},
+		{
+			Name:   "valid record auth token (prefixed/case-insensitive)",
+			Method: http.MethodGet,
+			URL:    "/my/test",
+			Headers: map[string]string{
+				"Authorization": "bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjRxMXhsY2xtZmxva3UzMyIsInR5cGUiOiJhdXRoIiwiY29sbGVjdGlvbklkIjoiX3BiX3VzZXJzX2F1dGhfIiwiZXhwIjoyNTI0NjA0NDYxLCJyZWZyZXNoYWJsZSI6dHJ1ZX0.ZT3F0Z3iM-xbGgSG3LEKiEzHrPHr8t8IuHLZGGNuxLo",
+			},
+			BeforeTestFunc: func(t testing.TB, app *tests.TestApp, e *core.ServeEvent) {
+				e.Router.GET("/my/test", func(e *core.RequestEvent) error {
+					return e.String(200, "test123")
+				}).Bind(apis.RequireAuth())
+			},
+			ExpectedStatus:  200,
+			ExpectedContent: []string{"test123"},
+		},
+		{
+			Name:   "valid record auth token (prefixed/whitespace)",
+			Method: http.MethodGet,
+			URL:    "/my/test",
+			Headers: map[string]string{
+				"Authorization": "   Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjRxMXhsY2xtZmxva3UzMyIsInR5cGUiOiJhdXRoIiwiY29sbGVjdGlvbklkIjoiX3BiX3VzZXJzX2F1dGhfIiwiZXhwIjoyNTI0NjA0NDYxLCJyZWZyZXNoYWJsZSI6dHJ1ZX0.ZT3F0Z3iM-xbGgSG3LEKiEzHrPHr8t8IuHLZGGNuxLo",
+			},
+			BeforeTestFunc: func(t testing.TB, app *tests.TestApp, e *core.ServeEvent) {
+				e.Router.GET("/my/test", func(e *core.RequestEvent) error {
+					return e.String(200, "test123")
+				}).Bind(apis.RequireAuth())
+			},
+			ExpectedStatus:  200,
+			ExpectedContent: []string{"test123"},
+		},
+		{
 			Name:   "valid record auth token with collection not in the restricted list",
 			Method: http.MethodGet,
 			URL:    "/my/test",


### PR DESCRIPTION
The RequireAuth middleware is handing the `"Bearer "` prefix in the authorization header in a case-senstive way. This caused issues for me when running the OpenID Connect conformance tests against the [PocketBase OAuth2 Plugin](https://github.com/benjamesfleming/pocketbase-ext-oauth2) I'm building. For the plugin, I'm hoping to keep the native PocketBase authentication stack by using normal Access Tokens + RequireAuth().

This pull request updates the `"Bearer "` prefix handling to be case-insensitive and adds tests to ensure correct handling.

Reference: https://auth0.com/blog/the-bearer-token-case/