### PR TITLE
Remove max-width constraint from backup-name

### DIFF
--- a/ui/src/components/settings/BackupsList.svelte
+++ b/ui/src/components/settings/BackupsList.svelte
@@ -214,7 +214,6 @@
         }
     }
     .backup-name {
-        max-width: 300px;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;


### PR DESCRIPTION
After 300px the backup names start to displays an ellipsis (...) , I'm just removing this from the CSS so that we can see the full name of the backup in screens that are wide enough 

 

<table>
<tr>
 <td> Before
 <td> After
<tr>
 <td> 
<img width="1706" height="844" alt="bd30c663b10fddd7a8131b502aa53f91c8b946982afe88ab9f17cc074974f37f" src="https://github.com/user-attachments/assets/fc5e2c7e-1a1a-40ad-91c9-c3ef33fc8aaa" />
 <td> 
<img width="1680" height="1204" alt="CleanShot 2026-02-19 at 10 07 35@2x" src="https://github.com/user-attachments/assets/9415272e-c6cf-4914-b3f1-065bae5f10e1" />

</table>