### PR TITLE
Fix high memory usage in RereadableReadCloser

### DIFF
--- a/apis/batch.go
+++ b/apis/batch.go
@@ -197,7 +197,6 @@ func (p *batchProcessor) Process(batch []*core.InternalRequest, timeout time.Dur
 
 		go func() {
 			err := p.process(txApp, batch, 0)
-
 			if err != nil {
 				err = validation.Errors{
 					"requests": validation.Errors{
@@ -261,7 +260,6 @@ func (p *batchProcessor) process(activeApp core.App, batch []*core.InternalReque
 				return err
 			},
 		)
-
 		if err != nil {
 			return err
 		}
@@ -364,6 +362,7 @@ func processInternalRequest(
 	// assign request
 	event.Request = r
 	event.Request.Body = &router.RereadableReadCloser{ReadCloser: r.Body} // enables multiple reads
+	defer event.Request.Body.Close()
 
 	// assign response
 	rec := httptest.NewRecorder()

--- a/tools/router/rereadable_read_closer.go
+++ b/tools/router/rereadable_read_closer.go
@@ -1,9 +1,11 @@
 package router
 
 import (
-	"bytes"
 	"io"
+	"os"
 )
+
+const defaultMaxMemory = 10 << 20 // 10 MB
 
 var (
 	_ io.ReadCloser = (*RereadableReadCloser)(nil)
@@ -17,44 +19,130 @@ type Rereader interface {
 
 // RereadableReadCloser defines a wrapper around a io.ReadCloser reader
 // allowing to read the original reader multiple times.
+//
+// It caches the read data in memory up to MaxMemory and then switches
+// to a temporary file on disk to prevent excessive memory allocations.
 type RereadableReadCloser struct {
 	io.ReadCloser
 
-	copy   *bytes.Buffer
-	active io.Reader
+	MaxMemory int64
+
+	file       *os.File
+	memBuf     []byte
+	readOffset int64
+	writeSize  int64
+	sourceEOF  bool
 }
 
 // Read implements the standard io.Reader interface.
 //
 // It reads up to len(b) bytes into b and at at the same time writes
-// the read data into an internal bytes buffer.
+// the read data into an internal bytes buffer or a temporary file.
 //
 // On EOF the r is "rewinded" to allow reading from r multiple times.
 func (r *RereadableReadCloser) Read(b []byte) (int, error) {
-	if r.active == nil {
-		if r.copy == nil {
-			r.copy = &bytes.Buffer{}
-		}
-		r.active = io.TeeReader(r.ReadCloser, r.copy)
+	if r.MaxMemory == 0 {
+		r.MaxMemory = defaultMaxMemory
 	}
 
-	n, err := r.active.Read(b)
+	if r.readOffset < r.writeSize {
+		limit := r.writeSize - r.readOffset
+		if int64(len(b)) > limit {
+			b = b[:limit]
+		}
+
+		var n int
+		var err error
+		if r.file != nil {
+			n, err = r.file.ReadAt(b, r.readOffset)
+			if err == io.EOF {
+				err = nil
+			}
+		} else {
+			n = copy(b, r.memBuf[r.readOffset:])
+		}
+
+		r.readOffset += int64(n)
+
+		if r.readOffset == r.writeSize && r.sourceEOF {
+			r.Reread()
+			return n, io.EOF
+		}
+		return n, err
+	}
+
+	if r.sourceEOF {
+		r.Reread()
+		return 0, io.EOF
+	}
+
+	n, err := r.ReadCloser.Read(b)
+	if n > 0 {
+		if storeErr := r.store(b[:n]); storeErr != nil {
+			return n, storeErr
+		}
+		r.readOffset += int64(n)
+	}
+
 	if err == io.EOF {
+		r.sourceEOF = true
 		r.Reread()
 	}
 
 	return n, err
 }
 
+func (r *RereadableReadCloser) store(p []byte) error {
+	r.writeSize += int64(len(p))
+
+	if r.file != nil {
+		_, err := r.file.Write(p)
+		return err
+	}
+
+	if int64(len(r.memBuf))+int64(len(p)) > r.MaxMemory {
+		f, err := os.CreateTemp("", "rereader-")
+		if err != nil {
+			return err
+		}
+		r.file = f
+
+		if len(r.memBuf) > 0 {
+			if _, err := r.file.Write(r.memBuf); err != nil {
+				return err
+			}
+			r.memBuf = nil
+		}
+
+		_, err = r.file.Write(p)
+		return err
+	}
+
+	r.memBuf = append(r.memBuf, p...)
+	return nil
+}
+
 // Reread satisfies the [Rereader] interface and resets the r internal state to allow rereads.
 //
 // note: not named Reset to avoid conflicts with other reader interfaces.
 func (r *RereadableReadCloser) Reread() {
-	if r.copy == nil || r.copy.Len() == 0 {
-		return // nothing to reset or it has been already reset
+	r.readOffset = 0
+}
+
+// Close closes the underlying reader and cleans up any temporary files.
+func (r *RereadableReadCloser) Close() error {
+	var err error
+	if r.file != nil {
+		name := r.file.Name()
+		r.file.Close()
+		err = os.Remove(name)
 	}
 
-	oldCopy := r.copy
-	r.copy = &bytes.Buffer{}
-	r.active = io.TeeReader(oldCopy, r.copy)
+	if r.ReadCloser != nil {
+		closeErr := r.ReadCloser.Close()
+		if err == nil {
+			err = closeErr
+		}
+	}
+	return err
 }

--- a/tools/router/rereadable_read_closer_test.go
+++ b/tools/router/rereadable_read_closer_test.go
@@ -1,17 +1,16 @@
-package router_test
+package router
 
 import (
 	"io"
+	"os"
 	"strings"
 	"testing"
-
-	"github.com/pocketbase/pocketbase/tools/router"
 )
 
 func TestRereadableReadCloser(t *testing.T) {
 	content := "test"
 
-	rereadable := &router.RereadableReadCloser{
+	rereadable := &RereadableReadCloser{
 		ReadCloser: io.NopCloser(strings.NewReader(content)),
 	}
 
@@ -24,5 +23,50 @@ func TestRereadableReadCloser(t *testing.T) {
 		if str := string(result); str != content {
 			t.Fatalf("[read:%d] Expected %q, got %q", i, content, result)
 		}
+	}
+
+	// verify that no file was created for small payloads
+	if rereadable.file != nil {
+		t.Fatal("Expected no temp file to be created")
+	}
+}
+
+func TestRereadableReadCloserFileFallback(t *testing.T) {
+	content := "this content is strictly longer than the defined memory limit"
+
+	rereadable := &RereadableReadCloser{
+		ReadCloser: io.NopCloser(strings.NewReader(content)),
+		MaxMemory:  10,
+	}
+
+	// read multiple times
+	for i := 0; i < 3; i++ {
+		result, err := io.ReadAll(rereadable)
+		if err != nil {
+			t.Fatalf("[read:%d] %v", i, err)
+		}
+		if str := string(result); str != content {
+			t.Fatalf("[read:%d] Expected %q, got %q", i, content, result)
+		}
+	}
+
+	// verify that a temp file was created
+	if rereadable.file == nil {
+		t.Fatal("Expected a temp file to be created")
+	}
+
+	fileName := rereadable.file.Name()
+	if _, err := os.Stat(fileName); err != nil {
+		t.Fatalf("Expected temp file %q to exist on disk, got error: %v", fileName, err)
+	}
+
+	// ensure resources and temp files are cleaned up
+	if err := rereadable.Close(); err != nil {
+		t.Fatalf("Failed to close reader: %v", err)
+	}
+
+	// verify that the temp file was deleted
+	if _, err := os.Stat(fileName); !os.IsNotExist(err) {
+		t.Fatalf("Expected temp file %q to be deleted, got error: %v", fileName, err)
 	}
 }

--- a/tools/router/router.go
+++ b/tools/router/router.go
@@ -133,6 +133,7 @@ func (r *Router[T]) loadMux(mux *http.ServeMux, group *RouterGroup[T], parents [
 
 				// wrap the request body to allow multiple reads
 				req.Body = &RereadableReadCloser{ReadCloser: req.Body}
+				defer req.Body.Close()
 
 				event, cleanupFunc := r.eventFactory(resp, req)
 


### PR DESCRIPTION
This fixes the high memory usage of the RereadableReadCloser as discussed in #7572

The reader now switches to a temporary file after 10mb were read (similar to how the [multipart package](https://cs.opensource.google/go/go/+/refs/tags/go1.26.1:src/mime/multipart/formdata.go;l=41) does it)

When uploading a 2gb file with the old version the memory usage spiked to ~3gb for me, the new version stays stable at ~50mb :)
Here are the pprof heap details if you want to double-check:
[new_profile.pb.gz](https://github.com/user-attachments/files/25824937/new_profile.pb.gz)
[old_profile.pb.gz](https://github.com/user-attachments/files/25824938/old_profile.pb.gz)

I had to add a deferred `Close()` to all the places where the reader was used so the temporary file gets deleted. 
What you may need to confirm is whether to also close the underlying reader in the same `Close()` function.

Lastly I added a new test that confirms the logic and ensures the temporary file is also deleted when it is created.