### PR TITLE
Short-circuit top-level OR branches in rule evaluation

### DIFF
--- a/core/record_field_resolver.go
+++ b/core/record_field_resolver.go
@@ -28,6 +28,9 @@ const (
 // ensure that `search.FieldResolver` interface is implemented
 var _ search.FieldResolver = (*RecordFieldResolver)(nil)
 
+// ensure that `search.StaticResolver` interface is implemented
+var _ search.StaticResolver = (*RecordFieldResolver)(nil)
+
 // RecordFieldResolver defines a custom search resolver struct for
 // managing Record model search fields.
 //
@@ -74,6 +77,14 @@ func (r *RecordFieldResolver) AllowHiddenFields() bool {
 // SetAllowHiddenFields enables or disables hidden fields filtering.
 func (r *RecordFieldResolver) SetAllowHiddenFields(allowHiddenFields bool) {
 	r.allowHiddenFields = allowHiddenFields
+}
+
+// StaticRequestData implements `search.StaticResolver` interface.
+//
+// Returns the pre-built static request info map containing auth, body,
+// query, headers, method and context data.
+func (r *RecordFieldResolver) StaticRequestData() map[string]any {
+	return r.staticRequestInfo
 }
 
 // NewRecordFieldResolver creates and initializes a new `RecordFieldResolver`.

--- a/tools/search/filter.go
+++ b/tools/search/filter.go
@@ -81,25 +81,34 @@ func (f FilterData) BuildExprWithLimit(
 
 	cacheKey := raw + "/" + strconv.Itoa(maxExpressions)
 
-	if data, ok := parsedFilterData.GetOk(cacheKey); ok {
-		return buildParsedFilterExpr(data, fieldResolver, &maxExpressions)
+	var data []fexpr.ExprGroup
+
+	if cached, ok := parsedFilterData.GetOk(cacheKey); ok {
+		data = cached
+	} else {
+		var err error
+		data, err = fexpr.Parse(raw)
+		if err != nil {
+			return nil, err
+		}
+
+		// store in cache
+		// (the limit size is arbitrary and it is there to prevent the cache growing too big)
+		parsedFilterData.SetIfLessThanLimit(cacheKey, data, 500)
 	}
 
-	data, err := fexpr.Parse(raw)
-	if err != nil {
-		// depending on the users demand we may allow empty expressions
-		// (aka. expressions consisting only of whitespaces or comments)
-		// but for now disallow them as it seems unnecessary
-		// if errors.Is(err, fexpr.ErrEmpty) {
-		// return dbx.NewExp("1=1"), nil
-		// }
-
-		return nil, err
+	// short-circuit top-level OR branches that only reference @request.* fields
+	if sr, ok := fieldResolver.(StaticResolver); ok {
+		result := tryShortCircuitOr(data, sr.StaticRequestData())
+		switch {
+		case result.passed:
+			return dbx.NewExp("1=1"), nil
+		case result.remaining != nil && len(result.remaining) == 0:
+			return dbx.NewExp("0=1"), nil // all cheap branches, none matched
+		case result.remaining != nil:
+			data = result.remaining
+		}
 	}
-
-	// store in cache
-	// (the limit size is arbitrary and it is there to prevent the cache growing too big)
-	parsedFilterData.SetIfLessThanLimit(cacheKey, data, 500)
 
 	return buildParsedFilterExpr(data, fieldResolver, &maxExpressions)
 }

--- a/tools/search/filter_shortcircuit.go
+++ b/tools/search/filter_shortcircuit.go
@@ -1,0 +1,307 @@
+package search
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ganigeorgiev/fexpr"
+	"github.com/spf13/cast"
+)
+
+type shortCircuitResult struct {
+	passed    bool              // a cheap branch evaluated to true → rule passes
+	remaining []fexpr.ExprGroup // expensive branches only (nil = no optimization possible)
+}
+
+// tryShortCircuitOr attempts to evaluate cheap OR branches that only reference
+// @request.* fields against the provided static data.
+//
+// It operates in two phases:
+//
+// Phase 1 (top-level ORs): splits the expression at top-level OR boundaries
+// and evaluates cheap branches. If any cheap branch matches, the entire rule
+// passes. If some don't match, they are excluded (removing the poisonous OR).
+//
+// Phase 2 (nested groups): when the top level is a pure AND chain, recurses
+// into nested parenthesized groups to simplify OR branches within them.
+// This handles the common rule pattern: A && (cheap || expensive).
+func tryShortCircuitOr(data []fexpr.ExprGroup, staticData map[string]any) shortCircuitResult {
+	branches := splitTopLevelOrs(data)
+
+	// Phase 1: top-level OR splitting
+	if len(branches) > 1 {
+		var expensive []fexpr.ExprGroup
+		anyOptimized := false
+
+		for _, branch := range branches {
+			if isCheapBranch(branch) {
+				if evaluateCheapBranch(branch, staticData) {
+					return shortCircuitResult{passed: true}
+				}
+				anyOptimized = true
+			} else {
+				if anyOptimized && len(expensive) == 0 && len(branch) > 0 {
+					fixed := make([]fexpr.ExprGroup, len(branch))
+					copy(fixed, branch)
+					fixed[0].Join = fexpr.JoinAnd
+					expensive = append(expensive, fixed...)
+				} else {
+					expensive = append(expensive, branch...)
+				}
+			}
+		}
+
+		if anyOptimized {
+			if expensive == nil {
+				expensive = []fexpr.ExprGroup{}
+			}
+			return shortCircuitResult{remaining: expensive}
+		}
+
+		return shortCircuitResult{}
+	}
+
+	// Phase 2: no top-level ORs (pure AND chain at this level).
+	// Recurse into nested groups to simplify their internal OR branches.
+	return simplifyNestedOrs(data, staticData)
+}
+
+// simplifyNestedOrs walks an AND chain of expression groups and recursively
+// simplifies any nested parenthesized groups that contain OR branches.
+//
+// When a nested group simplifies to true, it is removed from the AND chain
+// (true AND X = X). When it simplifies to false, the entire chain is false
+// (false AND X = false).
+func simplifyNestedOrs(data []fexpr.ExprGroup, staticData map[string]any) shortCircuitResult {
+	result := make([]fexpr.ExprGroup, 0, len(data))
+	anyModified := false
+
+	for _, group := range data {
+		inner, ok := group.Item.([]fexpr.ExprGroup)
+		if !ok {
+			result = append(result, group)
+			continue
+		}
+
+		innerResult := tryShortCircuitOr(inner, staticData)
+
+		switch {
+		case innerResult.passed:
+			// group is always true → skip (AND chain: no-op)
+			anyModified = true
+		case innerResult.remaining != nil && len(innerResult.remaining) == 0:
+			// group is always false → entire AND chain is false
+			return shortCircuitResult{remaining: []fexpr.ExprGroup{}}
+		case innerResult.remaining != nil:
+			anyModified = true
+			newGroup := group
+			newGroup.Item = innerResult.remaining
+			result = append(result, newGroup)
+		default:
+			result = append(result, group)
+		}
+	}
+
+	if !anyModified {
+		return shortCircuitResult{}
+	}
+
+	if len(result) == 0 {
+		return shortCircuitResult{passed: true}
+	}
+
+	return shortCircuitResult{remaining: result}
+}
+
+// splitTopLevelOrs splits parsed expression groups at top-level OR boundaries.
+//
+// Given `A && B || C && D` parsed as [{A, &&}, {B, &&}, {C, ||}, {D, &&}],
+// this returns [[{A, &&}, {B, &&}], [{C, ||}, {D, &&}]].
+func splitTopLevelOrs(data []fexpr.ExprGroup) [][]fexpr.ExprGroup {
+	if len(data) == 0 {
+		return nil
+	}
+
+	var branches [][]fexpr.ExprGroup
+	var current []fexpr.ExprGroup
+
+	for _, group := range data {
+		if group.Join == fexpr.JoinOr && len(current) > 0 {
+			branches = append(branches, current)
+			current = []fexpr.ExprGroup{group}
+		} else {
+			current = append(current, group)
+		}
+	}
+
+	if len(current) > 0 {
+		branches = append(branches, current)
+	}
+
+	return branches
+}
+
+// isCheapBranch returns true if every identifier in the branch starts with
+// @request. (meaning it can be resolved from in-memory static data without SQL).
+func isCheapBranch(branch []fexpr.ExprGroup) bool {
+	for _, group := range branch {
+		if !isCheapGroup(group) {
+			return false
+		}
+	}
+	return true
+}
+
+func isCheapGroup(group fexpr.ExprGroup) bool {
+	switch item := group.Item.(type) {
+	case fexpr.Expr:
+		return isCheapToken(item.Left) && isCheapToken(item.Right)
+	case fexpr.ExprGroup:
+		return isCheapGroup(item)
+	case []fexpr.ExprGroup:
+		for _, g := range item {
+			if !isCheapGroup(g) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func isCheapToken(t fexpr.Token) bool {
+	switch t.Type {
+	case fexpr.TokenIdentifier:
+		return strings.HasPrefix(t.Literal, "@request.")
+	case fexpr.TokenText, fexpr.TokenNumber:
+		return true
+	default:
+		return false // functions, etc.
+	}
+}
+
+// evaluateCheapBranch evaluates a branch of ExprGroups against static data.
+// All identifiers must be @request.* fields. Returns false for any
+// unsupported construct (conservative — never incorrectly short-circuits).
+func evaluateCheapBranch(branch []fexpr.ExprGroup, staticData map[string]any) bool {
+	result := true
+
+	for i, group := range branch {
+		val := evalGroup(group, staticData)
+
+		if i == 0 {
+			result = val
+		} else if group.Join == fexpr.JoinOr {
+			result = result || val
+		} else {
+			result = result && val
+		}
+	}
+
+	return result
+}
+
+func evalGroup(group fexpr.ExprGroup, staticData map[string]any) bool {
+	switch item := group.Item.(type) {
+	case fexpr.Expr:
+		return evalExpr(item, staticData)
+	case fexpr.ExprGroup:
+		return evalGroup(item, staticData)
+	case []fexpr.ExprGroup:
+		return evaluateCheapBranch(item, staticData)
+	default:
+		return false
+	}
+}
+
+func evalExpr(expr fexpr.Expr, staticData map[string]any) bool {
+	left := resolveStaticToken(expr.Left, staticData)
+	right := resolveStaticToken(expr.Right, staticData)
+
+	leftStr := fmt.Sprint(left)
+	rightStr := fmt.Sprint(right)
+
+	switch expr.Op {
+	case fexpr.SignEq, fexpr.SignAnyEq:
+		return leftStr == rightStr
+	case fexpr.SignNeq, fexpr.SignAnyNeq:
+		return leftStr != rightStr
+	case fexpr.SignLike, fexpr.SignAnyLike:
+		return strings.Contains(leftStr, rightStr)
+	case fexpr.SignNlike, fexpr.SignAnyNlike:
+		return !strings.Contains(leftStr, rightStr)
+	case fexpr.SignLt, fexpr.SignAnyLt:
+		lf, rf, ok := toFloats(leftStr, rightStr)
+		return ok && lf < rf
+	case fexpr.SignLte, fexpr.SignAnyLte:
+		lf, rf, ok := toFloats(leftStr, rightStr)
+		return ok && lf <= rf
+	case fexpr.SignGt, fexpr.SignAnyGt:
+		lf, rf, ok := toFloats(leftStr, rightStr)
+		return ok && lf > rf
+	case fexpr.SignGte, fexpr.SignAnyGte:
+		lf, rf, ok := toFloats(leftStr, rightStr)
+		return ok && lf >= rf
+	default:
+		return false
+	}
+}
+
+// resolveStaticToken resolves a token to its Go value.
+// For identifiers, walks the static data map.
+// For text/number literals, returns the literal value.
+func resolveStaticToken(t fexpr.Token, staticData map[string]any) any {
+	switch t.Type {
+	case fexpr.TokenIdentifier:
+		return resolveStaticIdentifier(t.Literal, staticData)
+	case fexpr.TokenText:
+		return t.Literal
+	case fexpr.TokenNumber:
+		return t.Literal
+	default:
+		return nil
+	}
+}
+
+// resolveStaticIdentifier resolves @request.auth.scopes → staticData["auth"]["scopes"]
+func resolveStaticIdentifier(field string, staticData map[string]any) any {
+	// strip "@request." prefix
+	field = strings.TrimPrefix(field, "@request.")
+
+	parts := strings.Split(field, ".")
+	var current any = staticData
+
+	for _, part := range parts {
+		switch m := current.(type) {
+		case map[string]any:
+			var ok bool
+			current, ok = m[part]
+			if !ok {
+				return nil
+			}
+		case map[string]string:
+			v, ok := m[part]
+			if !ok {
+				return nil
+			}
+			return v
+		default:
+			return nil
+		}
+	}
+
+	return current
+}
+
+func toFloats(a, b string) (float64, float64, bool) {
+	af, err := cast.ToFloat64E(a)
+	if err != nil {
+		return 0, 0, false
+	}
+	bf, err := cast.ToFloat64E(b)
+	if err != nil {
+		return 0, 0, false
+	}
+	return af, bf, true
+}

--- a/tools/search/filter_shortcircuit_test.go
+++ b/tools/search/filter_shortcircuit_test.go
@@ -1,0 +1,650 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/ganigeorgiev/fexpr"
+)
+
+func TestSplitTopLevelOrs(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		filter         string
+		expectedCount  int
+		expectedLens   []int // length of each branch
+	}{
+		{
+			"empty",
+			"",
+			0,
+			nil,
+		},
+		{
+			"single expression (no OR)",
+			"a = 1",
+			1,
+			[]int{1},
+		},
+		{
+			"two AND expressions (no OR)",
+			"a = 1 && b = 2",
+			1,
+			[]int{2},
+		},
+		{
+			"two OR branches",
+			"a = 1 || b = 2",
+			2,
+			[]int{1, 1},
+		},
+		{
+			"three OR branches",
+			"a = 1 || b = 2 || c = 3",
+			3,
+			[]int{1, 1, 1},
+		},
+		{
+			"mixed AND and OR",
+			"a = 1 && b = 2 || c = 3 && d = 4",
+			2,
+			[]int{2, 2},
+		},
+		{
+			"OR with grouped expressions",
+			"(a = 1 && b = 2) || c = 3",
+			2,
+			[]int{1, 1},
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			if s.filter == "" {
+				result := splitTopLevelOrs(nil)
+				if len(result) != s.expectedCount {
+					t.Fatalf("expected %d branches, got %d", s.expectedCount, len(result))
+				}
+				return
+			}
+
+			data, err := fexpr.Parse(s.filter)
+			if err != nil {
+				t.Fatalf("failed to parse filter %q: %v", s.filter, err)
+			}
+
+			result := splitTopLevelOrs(data)
+			if len(result) != s.expectedCount {
+				t.Fatalf("expected %d branches, got %d", s.expectedCount, len(result))
+			}
+
+			if s.expectedLens != nil {
+				for i, expectedLen := range s.expectedLens {
+					if len(result[i]) != expectedLen {
+						t.Errorf("branch %d: expected %d groups, got %d", i, expectedLen, len(result[i]))
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestIsCheapBranch(t *testing.T) {
+	scenarios := []struct {
+		name     string
+		filter   string
+		branchN  int  // which OR branch to test (0-indexed)
+		expected bool
+	}{
+		{
+			"@request.auth field = text",
+			`@request.auth.collectionName = "bots"`,
+			0,
+			true,
+		},
+		{
+			"@request.context field",
+			`@request.context = "default"`,
+			0,
+			true,
+		},
+		{
+			"@request.method field",
+			`@request.method = "GET"`,
+			0,
+			true,
+		},
+		{
+			"@request.auth with LIKE",
+			`@request.auth.scopes ~ "relays"`,
+			0,
+			true,
+		},
+		{
+			"two @request fields ANDed",
+			`@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays"`,
+			0,
+			true,
+		},
+		{
+			"@collection reference (expensive)",
+			`@collection.relay_roles.user = @request.auth.id`,
+			0,
+			false,
+		},
+		{
+			"plain record field (expensive)",
+			`status = "active"`,
+			0,
+			false,
+		},
+		{
+			"mixed: cheap OR branch first, expensive second",
+			`@request.auth.collectionName = "bots" || @collection.relay_roles.user = @request.auth.id`,
+			0,
+			true,
+		},
+		{
+			"mixed: expensive OR branch",
+			`@request.auth.collectionName = "bots" || @collection.relay_roles.user = @request.auth.id`,
+			1,
+			false,
+		},
+		{
+			"number literal on right side",
+			`@request.auth.verified = 1`,
+			0,
+			true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			data, err := fexpr.Parse(s.filter)
+			if err != nil {
+				t.Fatalf("failed to parse filter %q: %v", s.filter, err)
+			}
+
+			branches := splitTopLevelOrs(data)
+			if s.branchN >= len(branches) {
+				t.Fatalf("branch %d out of range (have %d branches)", s.branchN, len(branches))
+			}
+
+			result := isCheapBranch(branches[s.branchN])
+			if result != s.expected {
+				t.Fatalf("expected isCheapBranch=%v, got %v", s.expected, result)
+			}
+		})
+	}
+}
+
+func TestEvaluateCheapBranch(t *testing.T) {
+	botData := map[string]any{
+		"context": "default",
+		"method":  "GET",
+		"auth": map[string]any{
+			"id":             "bot123",
+			"collectionName": "bots",
+			"scopes":         `["relays","users"]`,
+			"verified":       true,
+		},
+	}
+
+	humanData := map[string]any{
+		"context": "default",
+		"method":  "POST",
+		"auth": map[string]any{
+			"id":             "user456",
+			"collectionName": "users",
+			"scopes":         `["profile"]`,
+			"verified":       true,
+		},
+	}
+
+	noAuthData := map[string]any{
+		"context": "default",
+		"method":  "GET",
+		"auth":    nil,
+	}
+
+	scenarios := []struct {
+		name       string
+		filter     string
+		staticData map[string]any
+		expected   bool
+	}{
+		{
+			"bot matches collectionName check",
+			`@request.auth.collectionName = "bots"`,
+			botData,
+			true,
+		},
+		{
+			"human fails collectionName check",
+			`@request.auth.collectionName = "bots"`,
+			humanData,
+			false,
+		},
+		{
+			"bot matches collectionName AND scopes",
+			`@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays"`,
+			botData,
+			true,
+		},
+		{
+			"bot fails scopes check",
+			`@request.auth.collectionName = "bots" && @request.auth.scopes ~ "admin"`,
+			botData,
+			false,
+		},
+		{
+			"not-equal operator matches",
+			`@request.auth.collectionName != "bots"`,
+			humanData,
+			true,
+		},
+		{
+			"not-equal operator fails",
+			`@request.auth.collectionName != "bots"`,
+			botData,
+			false,
+		},
+		{
+			"not-like operator matches",
+			`@request.auth.scopes !~ "admin"`,
+			botData,
+			true,
+		},
+		{
+			"not-like operator fails",
+			`@request.auth.scopes !~ "relays"`,
+			botData,
+			false,
+		},
+		{
+			"method check",
+			`@request.method = "GET"`,
+			botData,
+			true,
+		},
+		{
+			"method check fails",
+			`@request.method = "GET"`,
+			humanData,
+			false,
+		},
+		{
+			"nil auth field resolves to <nil>",
+			`@request.auth.collectionName = "bots"`,
+			noAuthData,
+			false,
+		},
+		{
+			"context check",
+			`@request.context = "default"`,
+			botData,
+			true,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			data, err := fexpr.Parse(s.filter)
+			if err != nil {
+				t.Fatalf("failed to parse filter %q: %v", s.filter, err)
+			}
+
+			branches := splitTopLevelOrs(data)
+			if len(branches) == 0 {
+				t.Fatal("expected at least one branch")
+			}
+
+			result := evaluateCheapBranch(branches[0], s.staticData)
+			if result != s.expected {
+				t.Fatalf("expected evaluateCheapBranch=%v, got %v", s.expected, result)
+			}
+		})
+	}
+}
+
+func TestTryShortCircuitOr(t *testing.T) {
+	botData := map[string]any{
+		"context": "default",
+		"method":  "GET",
+		"auth": map[string]any{
+			"id":             "bot123",
+			"collectionName": "bots",
+			"scopes":         `["relays","users"]`,
+		},
+	}
+
+	humanData := map[string]any{
+		"context": "default",
+		"method":  "GET",
+		"auth": map[string]any{
+			"id":             "user456",
+			"collectionName": "users",
+			"scopes":         `["profile"]`,
+		},
+	}
+
+	scenarios := []struct {
+		name              string
+		filter            string
+		staticData        map[string]any
+		expectPassed      bool
+		expectNilRemain   bool // remaining == nil (no optimization)
+		expectRemainCount int  // len(remaining) when not nil
+	}{
+		{
+			"no OR → no optimization",
+			`@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays"`,
+			botData,
+			false,
+			true,
+			0,
+		},
+		{
+			"bot matches cheap branch → passed",
+			`@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays" || @collection.relay_roles.user = @request.auth.id`,
+			botData,
+			true,
+			false,
+			0,
+		},
+		{
+			"human fails cheap branch → only expensive remains",
+			`@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays" || @collection.relay_roles.user = @request.auth.id`,
+			humanData,
+			false,
+			false,
+			1, // just the expensive branch with one ExprGroup
+		},
+		{
+			"no cheap branches → no optimization",
+			`@collection.relay_roles.user = @request.auth.id || status = "active"`,
+			botData,
+			false,
+			true,
+			0,
+		},
+		{
+			"all cheap branches, none match → empty remaining",
+			`@request.auth.collectionName = "bots" || @request.auth.collectionName = "admin"`,
+			humanData,
+			false,
+			false,
+			0,
+		},
+		{
+			"all cheap, first matches → passed",
+			`@request.auth.collectionName = "bots" || @request.auth.collectionName = "users"`,
+			botData,
+			true,
+			false,
+			0,
+		},
+		{
+			"three branches: cheap-match, cheap-miss, expensive",
+			`@request.auth.collectionName = "bots" || @request.method = "DELETE" || @collection.relay_roles.user = @request.auth.id`,
+			botData,
+			true,
+			false,
+			0,
+		},
+		{
+			"three branches: cheap-miss, expensive, cheap-miss",
+			`@request.auth.collectionName = "admin" || @collection.relay_roles.user = @request.auth.id || @request.method = "DELETE"`,
+			humanData,
+			false,
+			false,
+			1, // just the expensive branch
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			data, err := fexpr.Parse(s.filter)
+			if err != nil {
+				t.Fatalf("failed to parse filter %q: %v", s.filter, err)
+			}
+
+			result := tryShortCircuitOr(data, s.staticData)
+
+			if result.passed != s.expectPassed {
+				t.Fatalf("expected passed=%v, got %v", s.expectPassed, result.passed)
+			}
+
+			if s.expectNilRemain {
+				if result.remaining != nil {
+					t.Fatalf("expected remaining to be nil, got %v", result.remaining)
+				}
+			} else if !s.expectPassed {
+				if result.remaining == nil {
+					t.Fatal("expected remaining to be non-nil")
+				}
+				if len(result.remaining) != s.expectRemainCount {
+					t.Fatalf("expected %d remaining groups, got %d", s.expectRemainCount, len(result.remaining))
+				}
+			}
+		})
+	}
+}
+
+func TestTryShortCircuitOrRemainingJoinOp(t *testing.T) {
+	// When the first branch is cheap and doesn't match, the second (expensive)
+	// branch should have its first ExprGroup's Join reset from OR to AND so
+	// it doesn't create an invalid SQL expression.
+	filter := `@request.auth.collectionName = "bots" || @collection.relay_roles.user = @request.auth.id`
+	humanData := map[string]any{
+		"auth": map[string]any{
+			"collectionName": "users",
+		},
+	}
+
+	data, err := fexpr.Parse(filter)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	result := tryShortCircuitOr(data, humanData)
+	if result.passed {
+		t.Fatal("expected passed=false")
+	}
+	if result.remaining == nil || len(result.remaining) == 0 {
+		t.Fatal("expected non-empty remaining")
+	}
+
+	// The first remaining group should have JoinAnd, not JoinOr
+	if result.remaining[0].Join != fexpr.JoinAnd {
+		t.Fatalf("expected first remaining group to have JoinAnd, got %q", result.remaining[0].Join)
+	}
+}
+
+func TestTryShortCircuitOrNested(t *testing.T) {
+	botData := map[string]any{
+		"context": "default",
+		"method":  "GET",
+		"auth": map[string]any{
+			"id":             "bot123",
+			"collectionName": "bots",
+			"scopes":         `["relays","users"]`,
+			"verified":       true,
+		},
+	}
+
+	humanData := map[string]any{
+		"context": "default",
+		"method":  "GET",
+		"auth": map[string]any{
+			"id":             "user456",
+			"collectionName": "users",
+			"scopes":         `["profile"]`,
+			"verified":       true,
+		},
+	}
+
+	scenarios := []struct {
+		name              string
+		filter            string
+		staticData        map[string]any
+		expectPassed      bool
+		expectNilRemain   bool
+		expectRemainCount int
+	}{
+		{
+			// A && (cheap_true || expensive) → remaining = [A]
+			"nested: bot matches cheap branch inside group",
+			`@request.auth.verified = true && ((@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays") || @collection.relay_roles.user = @request.auth.id)`,
+			botData,
+			false,
+			false,
+			1, // just the @request.auth.verified expression
+		},
+		{
+			// A && (cheap_false || expensive) → remaining = [A, (expensive)]
+			"nested: human fails cheap branch, expensive remains",
+			`@request.auth.verified = true && ((@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays") || @collection.relay_roles.user = @request.auth.id)`,
+			humanData,
+			false,
+			false,
+			2, // verified expression + simplified group
+		},
+		{
+			// A && (cheap_true || cheap_false) → remaining = [A]
+			"nested: all cheap, one matches → group true, remove from AND chain",
+			`@request.auth.verified = true && (@request.auth.collectionName = "bots" || @request.auth.collectionName = "admin")`,
+			botData,
+			false,
+			false,
+			1, // just verified
+		},
+		{
+			// A && (cheap_false || cheap_false) → false
+			"nested: all cheap, none match → AND chain is false",
+			`@request.auth.verified = true && (@request.auth.collectionName = "bots" || @request.auth.collectionName = "admin")`,
+			humanData,
+			false,
+			false,
+			0, // empty remaining → false
+		},
+		{
+			// (cheap_true || expensive) - only group, no other top-level terms
+			"nested: only group, cheap matches → passed",
+			`((@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays") || @collection.relay_roles.user = @request.auth.id)`,
+			botData,
+			true,
+			false,
+			0,
+		},
+		{
+			"nested: no cheap branches in group → no optimization",
+			`@request.auth.verified = true && (@collection.relay_roles.user = @request.auth.id || creator = @request.auth.id)`,
+			botData,
+			false,
+			true,
+			0,
+		},
+		{
+			// Real relays viewRule pattern: A && (expensive || record_field || cheap)
+			"nested: relays viewRule with bot - bot matches",
+			`@request.auth.id != "" && ((@collection.relay_roles:rr.user ?= @request.auth.id && @collection.relay_roles:rr.relay ?= id) || creator = @request.auth.id || (@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays"))`,
+			botData,
+			false,
+			false,
+			1, // just auth.id != ""
+		},
+		{
+			// Real relays viewRule pattern: human → remove cheap branch, keep expensive + record
+			"nested: relays viewRule with bot - human",
+			`@request.auth.id != "" && ((@collection.relay_roles:rr.user ?= @request.auth.id && @collection.relay_roles:rr.relay ?= id) || creator = @request.auth.id || (@request.auth.collectionName = "bots" && @request.auth.scopes ~ "relays"))`,
+			humanData,
+			false,
+			false,
+			2, // auth.id != "" + simplified group (expensive + record branches only)
+		},
+		{
+			// Real users viewRule pattern
+			"nested: users viewRule - bot matches",
+			`@request.auth.verified = true && ((@request.auth.collectionName = "users" && @collection.collaborations.auth_user ?= @request.auth.id && @collection.collaborations.user ?= id) || (@request.auth.collectionName = "bots" && @request.auth.scopes ~ "users"))`,
+			botData,
+			false,
+			false,
+			1, // just verified
+		},
+		{
+			// Users viewRule with human: bot branch removed, users+collab branch remains
+			"nested: users viewRule - human",
+			`@request.auth.verified = true && ((@request.auth.collectionName = "users" && @collection.collaborations.auth_user ?= @request.auth.id && @collection.collaborations.user ?= id) || (@request.auth.collectionName = "bots" && @request.auth.scopes ~ "users"))`,
+			humanData,
+			false,
+			false,
+			2, // verified + simplified group
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.name, func(t *testing.T) {
+			data, err := fexpr.Parse(s.filter)
+			if err != nil {
+				t.Fatalf("failed to parse filter %q: %v", s.filter, err)
+			}
+
+			result := tryShortCircuitOr(data, s.staticData)
+
+			if result.passed != s.expectPassed {
+				t.Fatalf("expected passed=%v, got %v", s.expectPassed, result.passed)
+			}
+
+			if s.expectNilRemain {
+				if result.remaining != nil {
+					t.Fatalf("expected remaining to be nil, got %v", result.remaining)
+				}
+			} else if !s.expectPassed {
+				if result.remaining == nil {
+					t.Fatal("expected remaining to be non-nil")
+				}
+				if len(result.remaining) != s.expectRemainCount {
+					t.Fatalf("expected %d remaining groups, got %d", s.expectRemainCount, len(result.remaining))
+				}
+			}
+		})
+	}
+}
+
+func TestResolveStaticIdentifier(t *testing.T) {
+	staticData := map[string]any{
+		"context": "default",
+		"method":  "GET",
+		"auth": map[string]any{
+			"id":             "abc123",
+			"collectionName": "users",
+			"scopes":         `["profile","admin"]`,
+		},
+		"query": map[string]string{
+			"filter": "test",
+		},
+	}
+
+	scenarios := []struct {
+		field    string
+		expected any
+	}{
+		{"@request.context", "default"},
+		{"@request.method", "GET"},
+		{"@request.auth.id", "abc123"},
+		{"@request.auth.collectionName", "users"},
+		{"@request.auth.scopes", `["profile","admin"]`},
+		{"@request.auth.nonexistent", nil},
+		{"@request.query.filter", "test"},
+		{"@request.nonexistent.field", nil},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.field, func(t *testing.T) {
+			result := resolveStaticIdentifier(s.field, staticData)
+			if result != s.expected {
+				t.Fatalf("expected %v (%T), got %v (%T)", s.expected, s.expected, result, result)
+			}
+		})
+	}
+}

--- a/tools/search/simple_field_resolver.go
+++ b/tools/search/simple_field_resolver.go
@@ -18,6 +18,17 @@ const (
 	NullFallbackEnforced NullFallbackPreference = 2
 )
 
+// StaticResolver is an optional interface that FieldResolvers can implement
+// to enable short-circuit evaluation of top-level OR branches that only
+// reference static request data (e.g., @request.auth.* fields).
+//
+// When implemented, BuildExpr will attempt to evaluate cheap OR branches
+// in Go before compiling to SQL, avoiding expensive LEFT JOINs when a
+// cheap branch already matches.
+type StaticResolver interface {
+	StaticRequestData() map[string]any
+}
+
 // ResolverResult defines a single FieldResolver.Resolve() successfully parsed result.
 type ResolverResult struct {
 	// Identifier is the plain SQL identifier/column that will be used


### PR DESCRIPTION
When a rule has OR branches that only reference @request.* fields (resolvable from in-memory RequestInfo), evaluate them in Go before compiling to SQL. This prevents expensive LEFT JOIN cartesian products from materializing when a cheap branch already matches.

- Add StaticResolver interface for FieldResolvers that expose static data
- RecordFieldResolver implements StaticResolver via staticRequestInfo
- Recursively simplify nested groups: A && (cheap || expensive) becomes A && (expensive) or just A when cheap matches