### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -671,7 +671,7 @@ and the minor performance boost that you may get when used on large records is n
 
 - Eagerly interrupt waiting for the email alert send in case it takes longer than 15s.
 
-- Normalized the hidden fields filter checks and allow targetting hidden fields in the List API rule.
+- Normalized the hidden fields filter checks and allow targeting hidden fields in the List API rule.
 
 - Fixed "Unique identify fields" input not refreshing on unique indexes change ([#6184](https://github.com/pocketbase/pocketbase/issues/6184)).
 
@@ -763,7 +763,7 @@ and the minor performance boost that you may get when used on large records is n
 - Added support for passing more than one id in the `Hook.Unbind` method for consistency with the router.
 
 - Added collection rules change list in the confirmation popup
-  (_to avoid getting anoying during development, the rules confirmation currently is enabled only when using https_).
+  (_to avoid getting annoying during development, the rules confirmation currently is enabled only when using https_).
 
 
 ## v0.23.1
@@ -806,7 +806,7 @@ There are a lot of changes but to highlight some of the most notable ones:
 - Option to specify custom `DBConnect` function as part of the app configuration to allow different `database/sql` SQLite drivers (_turso/libsql, sqlcipher, etc._) and custom builds.
   _Note that we no longer loads the `mattn/go-sqlite3` driver by default when building with `CGO_ENABLED=1` to avoid `multiple definition` linker errors in case different CGO SQLite drivers or builds are used. You can find an example how to enable it back if you want to in the [new documentation](https://pocketbase.io/docs/go-overview/#github-commattngo-sqlite3)._
 - New hooks allowing better control over the execution chain and error handling (_including wrapping an entire hook chain in a single DB transaction_).
-- Various `Record` model improvements (_support for get/set modifiers, simplfied file upload by treating the file(s) as regular field value like `record.Set("document", file)`, etc._).
+- Various `Record` model improvements (_support for get/set modifiers, simplified file upload by treating the file(s) as regular field value like `record.Set("document", file)`, etc._).
 - Dedicated fields structs with safer defaults to make it easier creating/updating collections programmatically.
 - Option to mark field as "Hidden", disallowing regular users to read or modify it (_there is also a dedicated Record hook to hide/unhide Record fields programmatically from a single place_).
 - Option to customize the default system collection fields (`id`, `email`, `password`, etc.).

--- a/CHANGELOG_16_22.md
+++ b/CHANGELOG_16_22.md
@@ -94,7 +94,7 @@
 
 - Refresh the old collections state in the Import UI after successful import submission ([#5861](https://github.com/pocketbase/pocketbase/issues/5861)).
 
-- Added randomized throttle on failed filter list requests as a very rudimentary measure since some security researches raised concern regarding the possibity of eventual side-channel attacks.
+- Added randomized throttle on failed filter list requests as a very rudimentary measure since some security researches raised concern regarding the possibility of eventual side-channel attacks.
 
 
 ## v0.22.24
@@ -496,7 +496,7 @@
   A negative or zero value means no tests timeout.
   If a single API test takes more than 3s to complete it will have a log message visible when the test fails or when `go test -v` flag is used.
 
-- Added timestamp at the beginning of the generated JSVM types file to avoid creating it everytime with the app startup.
+- Added timestamp at the beginning of the generated JSVM types file to avoid creating it every time with the app startup.
 
 
 ## v0.20.0
@@ -876,7 +876,7 @@
 
 - ⚠️ Deprecated `RelationOptions.DisplayFields` in favor of the new `SchemaField.Presentable` option to avoid the duplication when a single collection is referenced more than once and/or by multiple other collections.
 
-- ⚠️ Fill the `LastVerificationSentAt` and `LastResetSentAt` fields only after a successfull email send ([#3121](https://github.com/pocketbase/pocketbase/issues/3121)).
+- ⚠️ Fill the `LastVerificationSentAt` and `LastResetSentAt` fields only after a successful email send ([#3121](https://github.com/pocketbase/pocketbase/issues/3121)).
 
 - ⚠️ Skip API `fields` json transformations for non 20x responses ([#3176](https://github.com/pocketbase/pocketbase/issues/3176)).
 

--- a/CHANGELOG_8_15.md
+++ b/CHANGELOG_8_15.md
@@ -326,7 +326,7 @@
 
 - Added "tags" support for all Record and Model related event hooks.
 
-    The "tags" allow registering event handlers that will be called only on matching table name(s) or colleciton id(s)/name(s).
+    The "tags" allow registering event handlers that will be called only on matching table name(s) or collection id(s)/name(s).
     For example:
     ```go
     app.OnRecordBeforeCreateRequest("articles").Add(func(e *core.RecordCreateEvent) error {
@@ -840,7 +840,7 @@ Please check the individual SDK package changelog and apply the necessary change
     </tr>
   </table>
 
-- All datetime stings are now returned in ISO8601 format - with _Z_ suffix and space as separator between the date and time part:
+- All datetime strings are now returned in ISO8601 format - with _Z_ suffix and space as separator between the date and time part:
   <table class="d-table" width="100%">
     <tr>
       <th>Old</th>


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.