### PR TITLE
fix: close file descriptor on Seek error in fileblob NewRangeReader

### DIFF
--- a/tools/filesystem/internal/fileblob/fileblob.go
+++ b/tools/filesystem/internal/fileblob/fileblob.go
@@ -385,6 +385,7 @@ func (drv *driver) NewRangeReader(ctx context.Context, key string, offset, lengt
 
 	if offset > 0 {
 		if _, err := f.Seek(offset, io.SeekStart); err != nil {
+			f.Close()
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Fixes #7629

## What

In `tools/filesystem/internal/fileblob/fileblob.go`, `NewRangeReader` opens a file descriptor via `os.Open`, then seeks it when `offset > 0`. If the `Seek` call fails the error path returned without calling `f.Close()`, leaking the file descriptor.

## Change

One line: call `f.Close()` before returning the seek error.

```go
if offset > 0 {
    if _, err := f.Seek(offset, io.SeekStart); err != nil {
        f.Close()   // <-- added
        return nil, err
    }
}
```

This is consistent with how the rest of the codebase handles similar patterns (e.g. the `Copy` function in the same file calls `w.Close()` before returning an `io.Copy` error).